### PR TITLE
tiny: Removed extra padding from top of map infowindow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -83,3 +83,7 @@ img {
 .resources-list {
   list-style-type: none;
 }
+
+.gm-style .gm-style-iw-c {
+  padding-top: 0px
+}


### PR DESCRIPTION
**Before:**
<img width="160" alt="Screen Shot 2021-06-05 at 6 21 06 PM" src="https://user-images.githubusercontent.com/61166946/120909541-dcc8b800-c62a-11eb-909d-5f10eafab3f2.png">
**After:**
<img width="150" alt="Screen Shot 2021-06-05 at 6 20 40 PM" src="https://user-images.githubusercontent.com/61166946/120909539-d6d2d700-c62a-11eb-9d97-6ef5c274b599.png">

