### PR TITLE
fix: more user friendly messaging when entering invalid password

### DIFF
--- a/src/auth_components/Login.tsx
+++ b/src/auth_components/Login.tsx
@@ -26,8 +26,9 @@ export default function Login({
       await login(emailRef.current.value, passwordRef.current.value)
     } catch(error) {
       console.log(error.code)
+      const alteredMessage = error.message === 'The password is invalid or the user does not have a password.'? 'Wrong password, please try again.' : error.message
       console.log(error.message)
-      setMessage(error.message)
+      setMessage(alteredMessage)
     }
     setLoading(false)
   }

--- a/src/auth_components/Login.tsx
+++ b/src/auth_components/Login.tsx
@@ -26,9 +26,9 @@ export default function Login({
       await login(emailRef.current.value, passwordRef.current.value)
     } catch(error) {
       console.log(error.code)
-      const alteredMessage = error.message === 'The password is invalid or the user does not have a password.'? 'Wrong password, please try again.' : error.message
+      const userMessage = error.code === 'auth/wrong-password'? 'Wrong password, please try again.' : error.message
       console.log(error.message)
-      setMessage(alteredMessage)
+      setMessage(userMessage)
     }
     setLoading(false)
   }


### PR DESCRIPTION
Trello: https://trello.com/c/HBn6TMLh

Fix: more helpful messaging in Login modal for user with **valid email** that enters **incorrect password**

Before:
<img width="491" alt="Screen Shot 2021-08-03 at 11 17 29 PM" src="https://user-images.githubusercontent.com/61166946/128131566-523d7681-295a-42ca-963c-0ce7108596fc.png">

After:
<img width="455" alt="Screen Shot 2021-08-03 at 11 13 22 PM" src="https://user-images.githubusercontent.com/61166946/128131541-ce214f18-c4d8-488f-89c8-54ce293e3766.png">


