### PR TITLE
Update Home and About page links and text

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -18,7 +18,7 @@ const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = pro
           The purpose of this website is to help people in their search for safe and comfortable rent-reduced housing. It aims to supplement existing government resources by mapping all MFTE (Multifamily Tax Exemption) properties, with the option to search and filter for apartments that fit given criteria (e.g. number of bedrooms, neighborhood, building name). To keep a shortlist of properties, users can create a (free) login to view a personalized map and add notes.
         </p>
         <p className="lead">
-          We chose to highlight the MFTE program because of the relatively quick application turnaround, higher availability, and modern apartments in sought-after locations. However, MFTE is not the only rent-reduced program available, and it's not accessible to everyone. Please view official government resources for complete information on rent-reduced and affordable housing programs in Seattle.
+          We chose to highlight the MFTE program because of the relatively quick application turnaround, higher availability, and modern apartments in sought-after locations. However, MFTE is not the only rent-reduced program, and it's not available to everyone. Please view official government resources for complete information on rent-reduced and affordable housing programs in Seattle.
         </p>
         <p className="lead">Buildings shown on&nbsp;
           <a id="Buildings_tab"

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -9,37 +9,39 @@ const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = pro
     logging.info(`Loading ${props.name}`);
   }, [props.name])
 
-  // const [query, setQuery] = useState<string>("");
-
   return (
     <div className="jumbotron">
       <div className="container">
         <h1 className="display-5">About</h1>
         <hr className="my-4"></hr>
         <p className="lead">
-          MFTE Seattle is intended to help people find safe and comfortable rent-reduced housing. 
+          The purpose of this website is to help people in their search for safe and comfortable rent-reduced housing. It aims to supplement existing government resources by mapping all MFTE (Multifamily Tax Exemption) properties, with the option to search and filter for apartments that fit given criteria (e.g. number of bedrooms, neighborhood, building name). To keep a shortlist of properties, users can create a (free) login to view a personalized map and add notes.
         </p>
         <p className="lead">
-          The website focuses on the MFTE (Multifamily Tax Exemption) program because of the relatively quick application turnaround, high availability, and desirable buildings and locations.
+          We chose to highlight the MFTE program because of the relatively quick application turnaround, higher availability, and modern apartments in sought-after locations. However, MFTE is not the only rent-reduced program available, and it's not accessible to everyone. Please view official government resources for complete information on rent-reduced and affordable housing programs in Seattle.
+        </p>
+        <p className="lead">Buildings shown on&nbsp;
+          <a id="Buildings_tab"
+            href="./Buildings"
+            title="View the map of MFTE properties">
+            the map
+          </a>&nbsp;are sourced from the spreadsheet of&nbsp;
+          <a id="properties-spreadsheet-may-2023"
+            href="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Affordable_Housing_List.pdf"
+            title="Market-Rate Rental Properties with Affordable Housing Units spreadsheet by the City of Seattle - May 2023 update - PDF"
+            target="_blank"
+            rel="noreferrer">
+            Market-Rate Rental Properties with Affordable Housing Units Regulated by the City of Seattle (May 2023)
+          </a>.
         </p>
         <p className="lead">
-          All data is sourced from the list of properties participating in the MFTE and Incentive Zoning programs distributed by the City of Seattle Office of Housing. 
-        </p>
-        <p className="lead">
-          <strong>Resources from the Seattle Office of Housing: </strong>
+          <strong>Additional resources from the Seattle Office of Housing:</strong>
         </p>
         <ul className="resources-list lead">
           <li>
-            <a id="list-of-properties"
-              href="https://www.seattle.gov/Documents/Departments/Housing/HousingDevelopers/MultifamilyTaxExemption/MFTEParticipantContact.pdf"
-              target="_blank"
-              rel="noreferrer">
-              List of Properties
-            </a>
-          </li>
-          <li>
-            <a id="main-resources"
-              href="https://www.seattle.gov/housing/renters/find-housing#multifamilytaxexemptionmfteincentivezoning"
+            <a id="mfte-city-website"
+              href="https://www.seattle.gov/housing/renters/find-housing#affordableapartmentsinmarketratebuildings"
+              title="Information about the MFTE program and other income and rent restricted properties on the City of Seattle website"
               target="_blank"
               rel="noreferrer">
               Main Resources Page
@@ -47,29 +49,49 @@ const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = pro
           </li>
           <li>
             <a id="income-and-rent-limits"
-              href="http://www.seattle.gov/housing/property-managers/income-and-rent-limits#multifamilypropertytaxexemptionmfteprogram"
+              href="https://www.seattle.gov/documents/Departments/Housing/PropertyManagers/IncomeRentLimits/2023_Income_Rent_Limits_Rental.pdf"
+              title="Income and Rent Limits, effective May 15, 2023 - PDF"
               target="_blank"
               rel="noreferrer">
-              Income and Rent Limits
+              Income and Rent Limits (FY 2023)
+            </a>
+          </li>
+          <li>
+            <a id="renters-guide"
+              href="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Renters_Guide_7-2023.pdf"
+              title="Renters' Guide for Market-Rate Apartment Buildings with Affordable Units - July 2023 - PDF"
+              target="_blank"
+              rel="noreferrer">
+              Detailed Renter's Guide (July 2023)
             </a>
           </li>
           <li>
             <a id="mfte-faqs"
               href="https://www.seattle.gov/Documents/Departments/Housing/Renters/MFTE%20FAQ.pdf"
+              title="Two-page overview of the MFTE program. Note the map and income limits are outdated - 2018"
               target="_blank"
               rel="noreferrer">
-              MFTE FAQs
+              MFTE FAQs (2018)
             </a>
           </li>
-          <li>
-            <a id="renters-guide"
-              href="https://www.seattle.gov/Documents/Departments/Housing/Renters/MFTE.IZ.RentersGuide.pdf"
-              target="_blank"
-              rel="noreferrer">
-              Detailed Renter's Guide
-            </a>
-          </li>   
         </ul>
+        <hr className="my-4"></hr>
+        <p className="lead">This website was created by an&nbsp;
+          <a id="ada-website"
+            href="https://adadevelopersacademy.org/"
+            title="Ada Developers Academy website"
+            target="_blank"
+            rel="noreferrer">
+            Ada Developers Academy
+          </a>&nbsp;grad (and former MFTE apartment resident) in 2021 as her capstone. It is an&nbsp;
+          <a id="ada-website"
+            href="https://github.com/anyatokar/mfte-seattle"
+            title="MFTE Seattle GitHub"
+            target="_blank"
+            rel="noreferrer">
+            open source project
+          </a>.
+        </p>
       </div>
     </div>
   )

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -22,13 +22,13 @@ const HomePage: React.FunctionComponent<IPage> = props => {
       <div className="container">
         <h1 className="display-5">MFTE Seattle</h1>
         <hr className="my-4"></hr>
-        <p className="lead">Find modern rent-reduced apartments in Seattle through the Multifamily Tax Exemption program.</p>
+        <p className="lead">Find modern rent-reduced apartments in Seattle through the Multifamily Tax Exemption (MFTE) program.</p>
         <p className="lead">Use the&nbsp;
           <a id="Buildings_tab"
             href="./Buildings"
             title="View the map of MFTE properties">
             Buildings tab
-          </a>&nbsp;to view a map of properties which participate in the MFTE (Multifamily Tax Exemption) program. You can create an account to save properties to your own map and keep notes.
+          </a>&nbsp;to view a map of participating properties. Create an account to save properties to your own map and keep notes.
         </p>
         <p className="lead">
           While the property data for this website is sourced from the City of Seattle&nbsp;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -22,34 +22,35 @@ const HomePage: React.FunctionComponent<IPage> = props => {
       <div className="container">
         <h1 className="display-5">MFTE Seattle</h1>
         <hr className="my-4"></hr>
-        <p className="lead">
-          Find modern rent-reduced apartments in Seattle through the Multifamily Tax Exemption program.
+        <p className="lead">Find modern rent-reduced apartments in Seattle through the Multifamily Tax Exemption program.</p>
+        <p className="lead">Use the&nbsp;
+          <a id="Buildings_tab"
+            href="./Buildings"
+            title="View the map of MFTE properties">
+            Buildings tab
+          </a>&nbsp;to view a map of properties which participate in the MFTE (Multifamily Tax Exemption) program. You can create an account to save properties to your own map and keep notes.
         </p>
         <p className="lead">
-          This website is unaffiliated with the City of Seattle. Its intention is to help prospective MFTE tenants map the spreadsheet of properties provided by the City.
+          While the property data for this website is sourced from the City of Seattle&nbsp;
+          <a id="properties-spreadsheet-may-2023"
+            href="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Affordable_Housing_List.pdf"
+            title="Market-Rate Rental Properties with Affordable Housing Units spreadsheet by the City of Seattle - May 2023 update - PDF"
+            target="_blank"
+            rel="noreferrer">
+            property spreadsheet
+          </a>,&nbsp;this website is not affiliated with the City. Please refer to the&nbsp;
+          <a id="mfte-city-website"
+            href="https://www.seattle.gov/housing/renters/find-housing#affordableapartmentsinmarketratebuildings"
+            title="Information about the MFTE program and other income and rent restricted properties on the City of Seattle website"
+            target="_blank"
+            rel="noreferrer">
+            government site
+          </a>&nbsp;for complete information on MFTE including current income and rent limits.
         </p>
-        <ul className="resources-list lead">
-          <li>
-            <a id="MFTE_homepage"
-              href="https://www.seattle.gov/housing/renters/find-housing#multifamilytaxexemptionmfteincentivezoning"
-              target="_blank"
-              rel="noreferrer">
-              City of Seattle MFTE homepage
-            </a>
-          </li>
-          <li>
-            <a id="spreadsheet_of_properties: https://www.seattle.gov/Documents/Departments/Housing/HousingDevelopers/MultifamilyTaxExemption/MFTEParticipantContact.pdf"
-              href="https://www.seattle.gov/Documents/Departments/Housing/HousingDevelopers/MultifamilyTaxExemption/MFTEParticipantContact.pdf"
-              target="_blank"
-              rel="noreferrer">
-              Spreadsheet of properties
-            </a>
-          </li>
-        </ul>
         <hr className="my-4"></hr>
         <div className="btn-toolbar">
           <Button onClick={onClick} value="./buildings" variant="outline-info" className="btn-lg standalone-btn">View Buildings</Button>
-          <Button onClick={onClick} value="./about" variant="outline-info" className="btn-lg standalone-btn">About MFTE</Button>
+          <Button onClick={onClick} value="./about" variant="outline-info" className="btn-lg standalone-btn">About MFTE Seattle</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Summary of changes:**
- Updated Home and About page text with more details about the website. On the About page, added a sentence about who made the website. All with the goal of additional context and clarity. @mmcknett, the About tab can also say, "It is an [open source project](https://github.com/anyatokar/mfte-seattle) maintained by Anya Tokar and Matt McKnett" if you would like to have your name out there?
- Updated links on those 2 pages to reflect updates of government website.
- Added titles to all links to show up on hover (the grey in screenshot below appears on mouse hover)
<img width="325" alt="Screen Shot 2023-09-27 at 6 36 14 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/a6fd65f0-8105-4a41-8572-0650fbbe7327">

----
**Home page changes:**
<img width="1027" alt="Screen Shot 2023-09-27 at 6 38 41 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/04999923-d046-48cc-b902-395f8d8ef5c7">
<img width="962" alt="Screen Shot 2023-09-27 at 8 35 13 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/7f3bbb3f-ef76-4168-ba1a-b4c822679e99">


**About page changes:**
<img width="1029" alt="Screen Shot 2023-09-27 at 6 40 39 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/cacaca08-35f9-45e4-bc75-d725d96569e4">
<img width="1014" alt="Screen Shot 2023-09-27 at 8 35 07 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/ab5cbbb3-7144-44ef-ba04-da4d6115939b">
