### PR TITLE
Added a resources tab

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -102,6 +102,9 @@ export const Header = () => {
             <LinkContainer to='/about'>
               <Nav.Link>About</Nav.Link>
             </LinkContainer>
+            <LinkContainer to='/resources'>
+              <Nav.Link>Resources</Nav.Link>
+            </LinkContainer>
           </Nav>
           { currentUser ? (
           <>

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,7 +1,8 @@
 import IRoute from '../interfaces/IRoute';
+import HomePage from '../pages/home';
 import BuildingsPage from '../pages/buildings';
 import AboutPage from '../pages/about';
-import HomePage from '../pages/home';
+import ResourcesPage from '../pages/resources';
 import SavedHomesPage from '../pages/saved-homes';
 import DashboardPage from '../auth_components/Dashboard'
 
@@ -22,6 +23,12 @@ const routes: IRoute[] = [
     path: '/about',
     name: 'About Page',
     component: AboutPage,
+    exact: true
+  },
+  {
+    path: '/resources',
+    name: 'Resources Page',
+    component: ResourcesPage,
     exact: true
   },
   {

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -34,47 +34,6 @@ const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = pro
             Market-Rate Rental Properties with Affordable Housing Units Regulated by the City of Seattle (May 2023)
           </a>.
         </p>
-        <p className="lead">
-          <strong>Additional resources from the Seattle Office of Housing:</strong>
-        </p>
-        <ul className="resources-list lead">
-          <li>
-            <a id="mfte-city-website"
-              href="https://www.seattle.gov/housing/renters/find-housing#affordableapartmentsinmarketratebuildings"
-              title="Information about the MFTE program and other income and rent restricted properties on the City of Seattle website"
-              target="_blank"
-              rel="noreferrer">
-              Main Resources Page
-            </a>
-          </li>
-          <li>
-            <a id="income-and-rent-limits"
-              href="https://www.seattle.gov/documents/Departments/Housing/PropertyManagers/IncomeRentLimits/2023_Income_Rent_Limits_Rental.pdf"
-              title="Income and Rent Limits, effective May 15, 2023 - PDF"
-              target="_blank"
-              rel="noreferrer">
-              Income and Rent Limits (FY 2023)
-            </a>
-          </li>
-          <li>
-            <a id="renters-guide"
-              href="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Renters_Guide_7-2023.pdf"
-              title="Renters' Guide for Market-Rate Apartment Buildings with Affordable Units - July 2023 - PDF"
-              target="_blank"
-              rel="noreferrer">
-              Detailed Renter's Guide (July 2023)
-            </a>
-          </li>
-          <li>
-            <a id="mfte-faqs"
-              href="https://www.seattle.gov/Documents/Departments/Housing/Renters/MFTE%20FAQ.pdf"
-              title="Two-page overview of the MFTE program. Note the map and income limits are outdated - 2018"
-              target="_blank"
-              rel="noreferrer">
-              MFTE FAQs (2018)
-            </a>
-          </li>
-        </ul>
         <hr className="my-4"></hr>
         <p className="lead">This website was created by an&nbsp;
           <a id="ada-website"

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import IPage from '../interfaces/IPage';
+import logging from '../config/logging';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
+const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = props => {
+
+  useEffect(() => {
+    logging.info(`Loading ${props.name}`);
+  }, [props.name])
+
+  return (
+    <div className="jumbotron">
+      <div className="container">
+      <h1 className="display-5">Resources</h1>
+        <hr className="my-4"></hr>
+        <p className="lead">
+          From the Seattle Office of Housing:
+        </p>
+        <ul className="resources-list lead">
+          <li>
+            <a id="mfte-city-website"
+              href="https://www.seattle.gov/housing/renters/find-housing#affordableapartmentsinmarketratebuildings"
+              title="Information about the MFTE program and other income and rent restricted properties on the City of Seattle website"
+              target="_blank"
+              rel="noreferrer">
+              Main Resources Page
+            </a>
+          </li>
+          <a id="properties-spreadsheet-may-2023"
+            href="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Affordable_Housing_List.pdf"
+            title="Market-Rate Rental Properties with Affordable Housing Units spreadsheet by the City of Seattle - May 2023 update - PDF"
+            target="_blank"
+            rel="noreferrer">
+            MFTE Spreadsheet of Properties (May 2023)
+          </a>.
+          <li>
+            <a id="income-and-rent-limits"
+              href="https://www.seattle.gov/documents/Departments/Housing/PropertyManagers/IncomeRentLimits/2023_Income_Rent_Limits_Rental.pdf"
+              title="Income and Rent Limits, effective May 15, 2023 - PDF"
+              target="_blank"
+              rel="noreferrer">
+              Income and Rent Limits (FY 2023)
+            </a>
+          </li>
+          <li>
+            <a id="renters-guide"
+              href="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Renters_Guide_7-2023.pdf"
+              title="Renters' Guide for Market-Rate Apartment Buildings with Affordable Units - July 2023 - PDF"
+              target="_blank"
+              rel="noreferrer">
+              Detailed Renter's Guide (July 2023)
+            </a>
+          </li>
+          <li>
+            <a id="mfte-faqs"
+              href="https://www.seattle.gov/Documents/Departments/Housing/Renters/MFTE%20FAQ.pdf"
+              title="Two-page overview of the MFTE program. Note the map and income limits are outdated - 2018"
+              target="_blank"
+              rel="noreferrer">
+              MFTE FAQs (2018)
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default withRouter(AboutPage);


### PR DESCRIPTION
As I was working on the About page #29, thought it may be better to split the city resources out. We could continue adding onto the Resources tab as well, does not need to be just these links.

Can [compare this branch to update-main-and-about-links branch for diff](https://github.com/anyatokar/mfte-seattle/compare/update-main-and-about-page-links-and-text...create-resources-tab)

<img width="907" alt="Screen Shot 2023-09-27 at 9 17 59 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/6e129d53-5695-4ce6-a096-51ba2dd4e2fe">
<img width="1232" alt="Screen Shot 2023-09-27 at 9 18 05 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/f102af60-a40b-4ab2-bf57-34cb69868c4b">
