### PR TITLE
Added Contact Us page and wired up to Firestore

### DIFF
--- a/src/components/AllBuildingsCard.tsx
+++ b/src/components/AllBuildingsCard.tsx
@@ -58,7 +58,7 @@ export function AllBuildingsCard(props: AllBuildingsCardProps) {
         "state": state, 
         "zip": zip,
         "lat": lat,
-        "lng": lng, 
+        "lng": lng,
     })
     .then(() => {
       console.log("Building saved to user");

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -67,10 +67,12 @@ export const Header = () => {
     closeLogin()
     try {
       await logout()
-        setMessage("Logged out successfully")
+        setMessage("Logged out successfully.")
+        console.log(message)
         history.push("/")
     } catch {
-      setMessage("Failed to log out")
+      setMessage("Failed to log out.")
+      console.log(message)
     }
   }
 
@@ -99,11 +101,14 @@ export const Header = () => {
             <LinkContainer to='/buildings'>
               <Nav.Link>Buildings</Nav.Link>
             </LinkContainer>
+            <LinkContainer to='/resources'>
+              <Nav.Link>Resources</Nav.Link>
+            </LinkContainer>
             <LinkContainer to='/about'>
               <Nav.Link>About</Nav.Link>
             </LinkContainer>
-            <LinkContainer to='/resources'>
-              <Nav.Link>Resources</Nav.Link>
+            <LinkContainer to='/contact-us'>
+              <Nav.Link>Contact</Nav.Link>
             </LinkContainer>
           </Nav>
           { currentUser ? (

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -2,6 +2,7 @@ import IRoute from '../interfaces/IRoute';
 import HomePage from '../pages/home';
 import BuildingsPage from '../pages/buildings';
 import AboutPage from '../pages/about';
+import ContactPage from '../pages/contact';
 import ResourcesPage from '../pages/resources';
 import SavedHomesPage from '../pages/saved-homes';
 import DashboardPage from '../auth_components/Dashboard'
@@ -23,6 +24,12 @@ const routes: IRoute[] = [
     path: '/about',
     name: 'About Page',
     component: AboutPage,
+    exact: true
+  },
+  {
+    path: '/contact-us',
+    name: 'Contact Page',
+    component: ContactPage,
     exact: true
   },
   {

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -29,11 +29,21 @@ const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = p
     })
     .then(() => {
       console.log('Message successfully submitted!');
+      clearFields()
     })
     .catch((error) => {
       console.error("Error sending message: ", error);
     });
   };
+
+  function clearFields(): void {
+    setformFields({
+      authorName: '',
+      email: '',
+      subject: '',
+      message: '',
+    });
+  }
 
   const [formFields, setformFields] = useState({
     authorName: '',
@@ -54,13 +64,6 @@ const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = p
   const onformSubmit: React.FormEventHandler<HTMLFormElement> = (event): void => {
     event.preventDefault();
     sendMessageToDb(formFields)
-
-    setformFields({
-      authorName: '',
-      email: '',
-      subject: '',
-      message: '',
-    });
   };
 
   return (
@@ -86,6 +89,7 @@ const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = p
             <Form.Group className="form-group col-md-6">
               <Form.Control
                 required
+                type="email"
                 name="email"
                 id="email"
                 onChange={onInputChange}

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import IPage from '../interfaces/IPage';
+import logging from '../config/logging';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { Form, Button } from "react-bootstrap"
+import firebase from "../db/firebase";
+
+const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = props => {
+
+  useEffect(() => {
+    logging.info(`Loading ${props.name}`);
+  }, [props.name])
+
+  type formFieldsType = {
+    authorName: string,
+    email: string,
+    subject: string,
+    message: string,
+  }
+
+  function sendMessageToDb(formFields:formFieldsType): void {
+    firebase.firestore().collection("contactus").doc()
+    .set({
+      authorName: formFields.authorName,
+      email: formFields.email,
+      subject: formFields.subject,
+      message: formFields.message,
+      timestamp: new Date().toUTCString()
+    })
+    .then(() => {
+      console.log('Message successfully submitted!');
+    })
+    .catch((error) => {
+      console.error("Error sending message: ", error);
+    });
+  };
+
+  const [formFields, setformFields] = useState({
+    authorName: '',
+    email: '',
+    subject: '',
+    message: '',
+  });
+
+  // event handlers
+  const onInputChange: React.ChangeEventHandler<HTMLInputElement> = (event): void => {
+    const newformFields = {
+      ...formFields,
+    }
+    newformFields[event.target.name as keyof formFieldsType] = event.target.value;
+    setformFields(newformFields);
+  }
+
+  const onformSubmit: React.FormEventHandler<HTMLFormElement> = (event): void => {
+    event.preventDefault();
+    sendMessageToDb(formFields)
+
+    setformFields({
+      authorName: '',
+      email: '',
+      subject: '',
+      message: '',
+    });
+  };
+
+  return (
+    <div className="jumbotron">
+      <div className="container">
+        <h1 className="display-5">Contact us</h1>
+        <hr className="my-4"></hr>
+        <p className="lead">
+          We are always looking to improve this resource — your feedback is welcome and appreciated.
+        </p>
+        <Form onSubmit={onformSubmit}>
+          <Form.Group className="form-row">
+            <Form.Group className="form-group col-md-6">
+            <Form.Control
+              required
+              name="authorName"
+              id="authorName"
+              onChange={onInputChange}
+              value={formFields.authorName}
+              placeholder="Name"
+              />
+            </Form.Group>
+            <Form.Group className="form-group col-md-6">
+              <Form.Control
+                required
+                name="email"
+                id="email"
+                onChange={onInputChange}
+                value={formFields.email}
+                placeholder="Email"
+                />
+            </Form.Group>
+          </Form.Group>
+          <Form.Group className="form-group">
+            <Form.Label>Subject</Form.Label>
+            <Form.Control
+              required
+              as="select"
+              name="subject"
+              id="subject"
+              onChange={onInputChange}
+              value={formFields.subject}
+            >
+              <option key = 'blankChoice' hidden></option>
+              <option>Feature suggestion</option>
+              <option>Incorrect building data</option>
+              <option>Website bug report</option>
+              <option>Kind words</option>
+              <option>Other</option>
+            </Form.Control>
+          </Form.Group>
+          <Form.Group className="form-group col-mb-3">
+            <Form.Control
+              required
+              as="textarea"
+              name="message"
+              id="message"
+              rows={5}
+              onChange={onInputChange}
+              value={formFields.message}
+              placeholder="Message"
+            />
+          </Form.Group>
+          <Button type="submit" variant="info" className="btn-md standalone-btn">Send</Button>
+        </Form>
+      </div>
+    </div>
+  )
+}
+
+export default withRouter(ContactPage);

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -3,7 +3,7 @@ import IPage from '../interfaces/IPage';
 import logging from '../config/logging';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
-const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = props => {
+const ResourcesPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = props => {
 
   useEffect(() => {
     logging.info(`Loading ${props.name}`);
@@ -33,7 +33,7 @@ const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = pro
             target="_blank"
             rel="noreferrer">
             MFTE Spreadsheet of Properties (May 2023)
-          </a>.
+          </a>
           <li>
             <a id="income-and-rent-limits"
               href="https://www.seattle.gov/documents/Departments/Housing/PropertyManagers/IncomeRentLimits/2023_Income_Rent_Limits_Rental.pdf"
@@ -67,4 +67,4 @@ const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = pro
   )
 }
 
-export default withRouter(AboutPage);
+export default withRouter(ResourcesPage);


### PR DESCRIPTION
Created a Contact Us page with a React Bootstrap Form that submits to a Firestore "contactus" collection. Adjusts to desktop and smaller screens.

<img width="1329" alt="Screen Shot 2023-10-09 at 3 09 00 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/9746f617-f31e-4a0f-be49-a2e6ac94ae96">

<img width="541" alt="Screen Shot 2023-10-09 at 3 14 53 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/adf1ee7f-dbc8-4864-8240-487cd723400a">

I didn't add form validation for email. There's seems to be a simple way of doing it with Bootstrap (already done for SignUp) but I have not looked into it much. Can always add later.

