### PR TITLE
Fixed google api is already presented map error

### DIFF
--- a/src/Map/ReactMap.tsx
+++ b/src/Map/ReactMap.tsx
@@ -16,6 +16,10 @@ const center = {
   lng: -122.315
 };
 
+// Statically define libraries to avoid the "LoadScript has been reloaded
+// unintentionally!" performance warning.
+const LIBRARIES: ("places")[] = ["places"];
+
 export function ReactMap(props: IMap) {
   const { buildingsToMap = [] } = props;
   const [selectedBuilding, setSelectedBuilding] = useState<IBuilding | null>(null);
@@ -30,10 +34,14 @@ export function ReactMap(props: IMap) {
   const { isLoaded } = useJsApiLoader({
     id: 'google-map-script',
     googleMapsApiKey: firebaseConfig.apiKey,
-
+    libraries: LIBRARIES
   })
 
-  return isLoaded ? (
+  if (!isLoaded) {
+    return null
+  }
+
+  return (
     <GoogleMap
       mapContainerStyle={containerStyle}
       center={center}
@@ -54,5 +62,5 @@ export function ReactMap(props: IMap) {
         }
       </>
     </GoogleMap>
-  ) : <></>
+  )
 };

--- a/src/Map/ReactMap.tsx
+++ b/src/Map/ReactMap.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { GoogleMap, LoadScript } from '@react-google-maps/api';
+import { GoogleMap, useJsApiLoader } from '@react-google-maps/api';
 import { BuildingMarker } from './BuildingMarker';
 import IMap from '../interfaces/IMap';
 import IBuilding from '../interfaces/IBuilding';
@@ -16,10 +16,6 @@ const center = {
   lng: -122.315
 };
 
-// Statically define libraries to avoid the "LoadScript has been reloaded
-// unintentionally!" performance warning.
-const LIBRARIES: ("places")[] = ["places"];
-
 export function ReactMap(props: IMap) {
   const { buildingsToMap = [] } = props;
   const [selectedBuilding, setSelectedBuilding] = useState<IBuilding | null>(null);
@@ -31,33 +27,32 @@ export function ReactMap(props: IMap) {
   // eslint-disable-next-line react-hooks/exhaustive-deps -- No need for selectedBuilding in the deps list
   }, [buildingsToMap]);
 
-  return (
-    <LoadScript
-      googleMapsApiKey={ firebaseConfig.apiKey }
-      libraries={ LIBRARIES }
-      language="en"
-      version="quarterly"
+  const { isLoaded } = useJsApiLoader({
+    id: 'google-map-script',
+    googleMapsApiKey: firebaseConfig.apiKey,
+
+  })
+
+  return isLoaded ? (
+    <GoogleMap
+      mapContainerStyle={containerStyle}
+      center={center}
+      zoom={14}
+      options={{mapId: 'c8d48b060a22a457'}}
     >
-      <GoogleMap
-        mapContainerStyle={containerStyle}
-        center={center}
-        zoom={14}
-        options={{mapId: 'c8d48b060a22a457'}}
-      >
-        <>
-          {
-            buildingsToMap.map(building => 
-              <BuildingMarker
-                key={ building.buildingID }
-                building={ building }
-                isSelected={ building === selectedBuilding }
-                setSelectedBuilding={ setSelectedBuilding }
-                isSaved={ checkIsSaved(props.savedBuildings, building) }
-              />
-            )
-          }
-        </>
-      </GoogleMap>
-    </LoadScript>
-  )
+      <>
+        {
+          buildingsToMap.map(building =>
+            <BuildingMarker
+              key={ building.buildingID }
+              building={ building }
+              isSelected={ building === selectedBuilding }
+              setSelectedBuilding={ setSelectedBuilding }
+              isSaved={ checkIsSaved(props.savedBuildings, building) }
+            />
+          )
+        }
+      </>
+    </GoogleMap>
+  ) : <></>
 };


### PR DESCRIPTION
**Summary:** Replaced LoadScript with useJsApiLoader API to fix error where map wouldn't load when navigating to the map page multiple time per session.

**Bug description:** When navigating between tabs/buttons that pull up the MFTE Map tab, was seeing infinite "Loading..." and a message in the console that said "google api is already presented" - a LoadScript error.

**Notes:**
- I don't see this bug in the deployed app. Maybe it's related to one of the recent version bumps? Not sure.
- This is very similar if not the same as this discussion: [google api is already presented](https://stackoverflow.com/questions/63760821/google-api-is-already-presented-in-react-app)
- I followed the react-google-maps api docs (and the stackoverflow discussion) which suggested to use the useJsApiLoader API instead of LoadScript.

**Result:** Switching between the All Buildings button on home page and the MFTE Map tab loads map and doesn't produce an error.