### PR TITLE
Fixed footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,15 +35,5 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,7 +18,7 @@ const Application: React.FunctionComponent<{}> = props => {
   const modalStateHook = useState(ModalState.HIDDEN);
 
   return (
-    <div>
+    <div className='main'>
       <Router>
         <AuthProvider>
           <ModalContext.Provider value={ modalStateHook }>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -6,11 +6,17 @@ export const Footer = () => {
     <Container fluid className="footer">
       <Row>
         <Col className="p-0">
-          <Image src={houses} alt="Colorful houses in a neighborhood" className="footer-img"/>
+          <Image
+            className="footer-img"
+            src={houses}
+            alt="Colorful houses in a neighborhood"
+          />
         </Col>
       </Row>
       <Row>
-        <Col className="text-center p-0">Copyright © 2021-2023 Anya Tokar</Col>
+        <Col className="p-0 text-center">
+          Copyright © 2021-2023 Anya Tokar
+        </Col>
       </Row>
     </Container>
   )

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -81,7 +81,7 @@ export const Header = () => {
   }
 
   return (
-    <Navbar collapseOnSelect expand="lg">
+    <Navbar collapseOnSelect expand="lg" className="p-0">
       <Container fluid>
         <LinkContainer to='/'>
           <Navbar.Brand>

--- a/src/index.css
+++ b/src/index.css
@@ -30,13 +30,8 @@ html, body {
   margin-right: 1em;
 }
 
-.navbar-text {
+.navbar .nav-link, .navbar-text {
   color: black !important;
-}
-
-.navbar .nav-link {
-  color: black !important;
-  text-align: inherit;
 }
 
 .navbar .nav-link:hover {

--- a/src/index.css
+++ b/src/index.css
@@ -2,10 +2,6 @@ html, body {
   background: #eef6f6;
 }
 
-.footer-img {
-  width: 100%;
-}
-
 .diy-jumbotron {
   margin-top: 2em;
   max-width: 90%;
@@ -16,8 +12,6 @@ html, body {
   background: white;
   border-bottom-right-radius: 15%;
   border-bottom-left-radius: 15%;
-  padding-right: 0em;
-  padding-left: 0em;
   text-align: center;
 }
 
@@ -92,6 +86,10 @@ html, body {
 
 .resources-list {
   list-style-type: none;
+}
+
+.footer-img {
+  width: 100%;
 }
 
 .footer {

--- a/src/index.css
+++ b/src/index.css
@@ -2,12 +2,18 @@ html, body {
   background: #eef6f6;
 }
 
+.main {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .diy-jumbotron {
   margin-top: 2em;
   max-width: 90%;
 }
 
-/* main navbar */
+/* navbar section */
 .navbar {
   background: white;
   border-bottom-right-radius: 15%;
@@ -47,7 +53,7 @@ html, body {
   color: red !important;
   background: none;
 }
-/* end of main navbar */
+/* end of navbar section */
 
 .standalone-btn {
   margin: .5em;
@@ -69,6 +75,7 @@ html, body {
 
 .pills-page {
   margin-top: 2em;
+  flex: 1;
 }
 
 .building-row {

--- a/src/index.css
+++ b/src/index.css
@@ -51,9 +51,6 @@ html, body {
 }
 /* end of navbar section */
 
-.standalone-btn {
-  margin: .5em;
-}
 
 .notes-form-btn {
   margin-top: .5em;

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@ html, body {
 .diy-jumbotron {
   margin-top: 2em;
   max-width: 90%;
+  flex: 1;
 }
 
 /* navbar section */
@@ -100,7 +101,7 @@ html, body {
 }
 
 .footer {
-  padding-top: 3em;
+  padding-top: 1em;
 }
 
 .card-close-icon { 

--- a/src/pages/buildings.tsx
+++ b/src/pages/buildings.tsx
@@ -59,13 +59,13 @@ const BuildingsPage: React.FunctionComponent<IPage & RouteComponentProps<any>> =
   const [ savedBuildings, loadingSavedBuildings ] = useSavedBuildings();
 
   return (
-    <div>
+    <>
       {loading || loadingSavedBuildings ? (
         <Spinner animation="border" variant="warning" />
         ) : (<></>)
       }
       {/* search filter container */}
-      <Container fluid>
+      <Container fluid className="pills-page">
         {/* search */}
         <Row className="justify-content-center">
           <Col sm md={9} lg={8}>
@@ -106,7 +106,7 @@ const BuildingsPage: React.FunctionComponent<IPage & RouteComponentProps<any>> =
         <hr className="my-4"></hr>
       </Container>
 
-      <Container fluid>
+      <Container fluid className="pills-page">
         <Tab.Container id="sidebar" defaultActiveKey="map">
           <Row>
             <Col sm={2}>
@@ -132,7 +132,7 @@ const BuildingsPage: React.FunctionComponent<IPage & RouteComponentProps<any>> =
           </Row>
         </Tab.Container>
       </Container>
-    </div>
+    </>
   )
 }
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import IPage from '../interfaces/IPage';
 import logging from '../config/logging';
 import { useHistory } from "react-router-dom";
-import { Button, Container } from "react-bootstrap"
+import { Button, Container, Stack } from "react-bootstrap"
 
 const HomePage: React.FunctionComponent<IPage> = props => {
   useEffect(() => {
@@ -47,10 +47,22 @@ const HomePage: React.FunctionComponent<IPage> = props => {
       </p>
       <p className="lead"> Contact buildings directly for current availability.</p>
       <hr className="my-4"></hr>
-      <div className="btn-toolbar">
-        <Button onClick={onClick} value="./buildings" variant="outline-info" className="btn-lg standalone-btn">View Buildings</Button>
-        <Button onClick={onClick} value="./about" variant="outline-info" className="btn-lg standalone-btn">About MFTE Seattle</Button>
-      </div>
+      <Stack gap={3} >
+        <Button
+          className="btn-lg col-lg-4 col-xl-3"
+          variant="outline-info"
+          onClick={onClick}
+          value="./buildings">
+          View Buildings Map
+        </Button>
+        <Button
+          className="btn-lg col-lg-4 col-xl-3"
+          variant="outline-info"
+          onClick={onClick}
+          value="./about">
+          About MFTE Seattle
+        </Button>
+      </Stack>
     </Container>
   )
 }

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -17,7 +17,7 @@ const ResourcesPage: React.FunctionComponent<IPage & RouteComponentProps<any>> =
       <p className="lead">
         From the Seattle Office of Housing:
       </p>
-      <ul className="resources-list lead">
+      <ul className="resources-list">
         <li>
           <a id="mfte-city-website"
             href="https://www.seattle.gov/housing/renters/find-housing#affordableapartmentsinmarketratebuildings"

--- a/src/pages/saved-homes.tsx
+++ b/src/pages/saved-homes.tsx
@@ -17,56 +17,54 @@ const SavedByUserPage: React.FunctionComponent<IPage & RouteComponentProps<any>>
   }
 
   return (
-    <div>
-      <Container fluid className="pills-page">
-        <Tab.Container id="sidebar" defaultActiveKey="list">
-          <Row>
-            <Col sm={2}>
-              <Nav variant="pills" className="flex-column">
-                <Nav.Item>
-                  <Nav.Link eventKey="map" className="tab">Map</Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="list" className="tab">List</Nav.Link>
-                </Nav.Item>
-              </Nav>
-            </Col>
-            <Col sm={10}>
-              <Tab.Content>
-                <Row>
-                  {/* top margin size 3 for all screens (xs and up) | top margin size of 0 for medium screens and up */}
-                  <Col className="mt-3 mt-md-0">
-                    <p className="lead">Saved buildings — your short list of apartment buildings.</p>
-                    <p>The list and notes are private to your profile.</p>
-                  </Col>
-                </Row>
-                {loading && <Spinner animation="border" variant="warning" />}
-                {!loading && savedBuildings.length === 0 &&
-                  <>
-                    <br></br>
-                    <p>Empty for now! To start your list, use the Save button in the&nbsp;
-                      <a id="Buildings_tab"
-                        href="./Buildings"
-                        title="View the map of MFTE properties">
-                        MFTE Map
-                      </a>&nbsp;tab.
-                    </p>
-                  </>}
-                <Tab.Pane eventKey="map">
-                  <MapTab
-                    buildingsToMap={savedBuildings}
-                    savedBuildings={savedBuildings}
-                  />
-                </Tab.Pane>
-                <Tab.Pane eventKey="list">
-                  <SavedHomesList savedBuildings={savedBuildings}/>
-                </Tab.Pane>
-              </Tab.Content>
-            </Col>
-          </Row>
-        </Tab.Container>
-      </Container>
-    </div>
+    <Container fluid className="pills-page">
+      <Tab.Container id="sidebar" defaultActiveKey="list">
+        <Row>
+          <Col sm={2}>
+            <Nav variant="pills" className="flex-column">
+              <Nav.Item>
+                <Nav.Link eventKey="map" className="tab">Map</Nav.Link>
+              </Nav.Item>
+              <Nav.Item>
+                <Nav.Link eventKey="list" className="tab">List</Nav.Link>
+              </Nav.Item>
+            </Nav>
+          </Col>
+          <Col sm={10}>
+            <Tab.Content>
+              <Row>
+                {/* top margin size 3 for all screens (xs and up) | top margin size of 0 for medium screens and up */}
+                <Col className="mt-3 mt-md-0">
+                  <p className="lead">Saved buildings — your short list of apartment buildings.</p>
+                  <p>The list and notes are private to your profile.</p>
+                </Col>
+              </Row>
+              {loading && <Spinner animation="border" variant="warning" />}
+              {!loading && savedBuildings.length === 0 &&
+                <>
+                  <br></br>
+                  <p>Empty for now! To start your list, use the Save button in the&nbsp;
+                    <a id="Buildings_tab"
+                      href="./Buildings"
+                      title="View the map of MFTE properties">
+                      MFTE Map
+                    </a>&nbsp;tab.
+                  </p>
+                </>}
+              <Tab.Pane eventKey="map">
+                <MapTab
+                  buildingsToMap={savedBuildings}
+                  savedBuildings={savedBuildings}
+                />
+              </Tab.Pane>
+              <Tab.Pane eventKey="list">
+                <SavedHomesList savedBuildings={savedBuildings}/>
+              </Tab.Pane>
+            </Tab.Content>
+          </Col>
+        </Row>
+      </Tab.Container>
+    </Container>
   )
 }
 


### PR DESCRIPTION
Fixed issue where on mobile, when content is short, the footer be in the middle of the page. Desktop looks the same since there were no issues there. Used flexbox, tried a few other approaches but they didn't work for both large and small screens.

Short page on mobile:

Before
<img width="307" alt="Screen Shot 2023-10-25 at 3 36 56 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/5c8b5e86-a325-499b-8308-100ce20b6472">

After
<img width="310" alt="Screen Shot 2023-10-25 at 3 38 07 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/9ab27333-22e9-4488-b040-2c07cffac981">

Long page stays the same, meaning footer is only visible at the very end of content.
<img width="306" alt="Screen Shot 2023-10-25 at 3 39 03 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/4037215e-44e4-49f3-856a-fc478e14a8d7">
<img width="297" alt="Screen Shot 2023-10-25 at 3 39 10 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/391f6a7a-0f22-4fb0-b73b-f3baff0b0c03">

Minor:
- Added a Stacked Bootstrap component to home page buttons.
- Changed font size on Resources page.
