### PR TITLE
Prevent refresh on enter for search bar

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -18,7 +18,7 @@ export default function SearchInput(props: ISearchProps) {
   }, [debouncedSearchQuery, onChangeSearchQuery]);
 
   return (
-    <Form>
+    <Form onSubmit={(event) => event.preventDefault()}>
       <Form.Label htmlFor="search" className="mt-3">
         Search by neighborhood, address, building name, or zip code:
       </Form.Label>


### PR DESCRIPTION
**Issue:** Noticed when using search bar, if I hit the return key, the whole page refreshes (and doesn't save the filed values). We don't want anything to happen on return since the search bar is dynamic.

**Change:** Added onSelect event.preventDefault to search form