### PR TITLE
Added update user name functionality, improved notes form, added timestampPT

### DIFF
--- a/src/auth_components/Profile.tsx
+++ b/src/auth_components/Profile.tsx
@@ -1,44 +1,19 @@
-import { useState, useEffect } from "react"
 import { Card } from "react-bootstrap"
 import { useAuth } from "../contexts/AuthContext"
-import firebase from "../db/firebase";
 import { Container, Row, Col } from 'react-bootstrap';
 
 export default function Profile() {
   const { currentUser } = useAuth() as any
-  const [userData, setUserData] = useState(null) as any
-
-  // get user Name
-  useEffect(() => {
-    if (currentUser) {
-      const docRef = firebase.firestore().collection("users").doc(currentUser.uid)
-
-      docRef.get().then((doc) => {
-        if (doc.exists) {
-          const data = doc.data()
-          setUserData(data)
-          console.log("Document data:", data);
-        } else {
-          // doc.data() will be undefined in this case
-          console.log("No such document!");
-        }
-      }).catch((error) => {
-          console.log("Error getting document:", error);
-      });
-    } else {(
-      setUserData(null)
-    )}
-  }, [currentUser])
 
   return (
-    currentUser && userData &&
+    currentUser &&
     <Container fluid>
       <Row>
         <Col lg={6}>
           <Card>
             <Card.Body>
               <Card.Text>
-                <strong>Name: </strong>{userData.name}
+                <strong>Name: </strong>{currentUser.displayName}
               </Card.Text>
               <Card.Text>
                 <strong>Email: </strong>{currentUser.email}

--- a/src/auth_components/UpdateProfile.tsx
+++ b/src/auth_components/UpdateProfile.tsx
@@ -7,10 +7,13 @@ import { Container, Row, Col } from 'react-bootstrap';
 import { FirebaseError } from '@firebase/util';
 
 export default function UpdateProfile() {
+  // TODO: add useRef types, also maybe use useRef to dynamically update 
+  // user name in navbar and profile, and email in profile
+  const displayNameRef = useRef() as any
   const emailRef = useRef() as any
   const passwordRef = useRef() as any
   const passwordConfirmRef = useRef() as any
-  const { currentUser, updatePassword, updateEmail } = useAuth() as any
+  const { currentUser, updateDisplayName, updateEmail, updatePassword } = useAuth() as any
   const [message, setMessage] = useState("")
   const [loading, setLoading] = useState(false)
   const history = useHistory()
@@ -25,9 +28,14 @@ export default function UpdateProfile() {
     setLoading(true)
     setMessage("")
 
-    if (emailRef.current.value !== currentUser.email) {
-      promises.push(updateEmail(emailRef.current.value))
+    if (displayNameRef.current.value !== currentUser.displayName) {
+      promises.push(updateDisplayName(currentUser.uid, displayNameRef.current.value))
     }
+
+    if (emailRef.current.value !== currentUser.email) {
+      promises.push(updateEmail(currentUser.uid, emailRef.current.value))
+    }
+
     if (passwordRef.current.value) {
       promises.push(updatePassword(passwordRef.current.value))
     }
@@ -77,6 +85,17 @@ export default function UpdateProfile() {
               {message && !(message.includes("Success: ")) && <Alert variant="danger">{message}</Alert>}
 
               <Form onSubmit={handleFormSubmit}>
+                { currentUser.displayName &&
+                  <Form.Group id="displayName" className="form-group">
+                    <Form.Label>Name</Form.Label>
+                    <Form.Control
+                      required
+                      type="displayName"
+                      ref={displayNameRef}
+                      defaultValue={currentUser.displayName}
+                    />
+                  </Form.Group>
+                }
                 <Form.Group id="email" className="form-group">
                   <Form.Label>Email</Form.Label>
                   <Form.Control

--- a/src/auth_components/UpdateProfile.tsx
+++ b/src/auth_components/UpdateProfile.tsx
@@ -85,7 +85,7 @@ export default function UpdateProfile() {
               {message && !(message.includes("Success: ")) && <Alert variant="danger">{message}</Alert>}
 
               <Form onSubmit={handleFormSubmit}>
-                { currentUser.displayName &&
+                {currentUser.displayName &&
                   <Form.Group id="displayName" className="form-group">
                     <Form.Label>Name</Form.Label>
                     <Form.Control

--- a/src/components/BuildingCard.tsx
+++ b/src/components/BuildingCard.tsx
@@ -7,6 +7,7 @@ import IBuilding from "../interfaces/IBuilding";
 import { saveBuilding, deleteBuilding } from "../utils/firestoreUtils";
 import { ModalContext, ModalState } from "../contexts/ModalContext";
 import { AddressAndPhone, BuildingName } from './BuildingContactInfo';
+import { timestampPT } from "../utils/generalUtils";
 
 export interface AllBuildingsCardProps extends IBuilding {
   isSaved: boolean
@@ -88,18 +89,13 @@ export function BuildingCard(props: BuildingsCardProps) {
     }
   };
 
-  const timestamp = new Date().toLocaleString("en-US", {
-    timeZone: "America/Los_Angeles",
-    timeZoneName: "shortGeneric" 
-  })
-
   const updateNote = (noteToAdd: string) => {
     const savedHome = firebase.firestore().collection("users").doc(currentUser.uid).collection("savedHomes").where('buildingID','==', buildingID)
     savedHome.get().then(function(querySnapshot) {
       querySnapshot.forEach(function(doc) {
         return doc.ref.update({
           note: noteToAdd,
-          noteTimestamp: timestamp
+          noteTimestamp: timestampPT
         })
         .then(() => {
           console.log("Note successfully updated!");

--- a/src/components/BuildingCard.tsx
+++ b/src/components/BuildingCard.tsx
@@ -76,7 +76,6 @@ export function BuildingCard(props: BuildingsCardProps) {
   const [isNoteDifferent, setIsNoteDifferent] =useState(false)
 
   const handleChange = (event: any) => {
-    console.log("note", note)
     event.target.value !== note ? setIsNoteDifferent(true) : setIsNoteDifferent(false);
     setNoteToAdd(event.target.value);
   };
@@ -95,7 +94,7 @@ export function BuildingCard(props: BuildingsCardProps) {
       querySnapshot.forEach(function(doc) {
         return doc.ref.update({
           note: noteToAdd,
-          noteTimestamp: timestampPT
+          noteTimestamp: timestampPT()
         })
         .then(() => {
           console.log("Note successfully updated!");

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,6 +1,5 @@
 import { Container, Image, Navbar, Nav, Modal, Dropdown } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
-import firebase from "../db/firebase";
 
 import { useState, useEffect, useContext, useCallback } from "react";
 import Login from "../auth_components/Login";
@@ -14,7 +13,6 @@ import mftelogo from '../assets/images/mftelogo23.svg';
 export const Header = () => {
   const [message, setMessage] = useState("")
   const { currentUser, logout } = useAuth() as any
-  const [userData, setUserData] = useState(null) as any
   const history = useHistory()
   const [modalState, setModalState] = useContext(ModalContext);
 
@@ -31,26 +29,6 @@ export const Header = () => {
     closeLogin()
   }, [currentUser, closeLogin])
 
-  useEffect(() => {
-    if (currentUser) {
-      const docRef = firebase.firestore().collection("users").doc(currentUser.uid)
-
-      docRef.get().then((doc) => {
-        if (doc.exists) {
-          const data = doc.data()
-          setUserData(data)
-          console.log("Document data:", data);
-        } else {
-          // doc.data() will be undefined in this case
-          console.log("No such document!");
-        }
-      }).catch((error) => {
-          console.log("Error getting document:", error);
-      });
-    } else {(
-      setUserData(null)
-    )}
-  }, [currentUser])
 
   // Logout
   async function handleLogout() {
@@ -113,7 +91,7 @@ export const Header = () => {
           </Nav>
           { currentUser ? (
           <Nav>
-            <Navbar.Text>{userData ? `Hi, ${userData.name}!` : ''}</Navbar.Text>
+            <Navbar.Text>{currentUser.displayName && `Hi, ${currentUser.displayName}!`}</Navbar.Text>
             <LinkContainer to='/dashboard'>
               <Nav.Link active={false}>Profile</Nav.Link>
             </LinkContainer>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -91,7 +91,7 @@ export const Header = () => {
           </Nav>
           { currentUser ? (
           <Nav>
-            <Navbar.Text>{currentUser.displayName && `Hi, ${currentUser.displayName}!`}</Navbar.Text>
+            <Navbar.Text className="mr-lg-4 font-italic">{currentUser.displayName && `Hi, ${currentUser.displayName}!`}</Navbar.Text>
             <LinkContainer to='/dashboard'>
               <Nav.Link active={false}>Profile</Nav.Link>
             </LinkContainer>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -22,7 +22,7 @@ export function AuthProvider({ children}: IProps) {
           firebase.firestore().collection('users').doc(cred.user.uid).update({
             email: cred.user.email,
             name: name,
-            signupTimestamp: timestampPT
+            signupTimestamp: timestampPT()
           })
         }
       })
@@ -41,27 +41,11 @@ export function AuthProvider({ children}: IProps) {
     return auth.sendPasswordResetEmail(email)
   }
 
-  function updateNameFirestore(uid: string, name: string) {
-    firebase.firestore().collection('users').doc(uid).update({
-      name: name,
-      updateNameTimestamp: timestampPT
-    })
-  }
-
-  function updateEmailFirestore(uid: string, email: string) {
-    firebase.firestore().collection('users').doc(uid).update({
-      email: email,
-      updateEmailTimestamp: timestampPT
-    })
-  }
-
-  function updateDisplayName(uid: string, displayName: string) {
-    updateNameFirestore(uid, displayName)
+  function updateDisplayName(displayName: string) {
     return currentUser.updateProfile({displayName: displayName})
   }
 
-  function updateEmail(uid: string, email: string) {
-    updateEmailFirestore(uid, email)
+  function updateEmail(email: string) {
     return currentUser.updateEmail(email)
   }
 
@@ -74,7 +58,6 @@ export function AuthProvider({ children}: IProps) {
       setCurrentUser(user)
       setLoading(false)
     })
-
     return unsubscribe
   }, [])
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -22,7 +22,7 @@ export function AuthProvider({ children}: IProps) {
           firebase.firestore().collection('users').doc(cred.user.uid).update({
             email: cred.user.email,
             name: name,
-            timestamp: timestampPT
+            signupTimestamp: timestampPT
           })
         }
       })
@@ -44,14 +44,14 @@ export function AuthProvider({ children}: IProps) {
   function updateNameFirestore(uid: string, name: string) {
     firebase.firestore().collection('users').doc(uid).update({
       name: name,
-      timestamp: timestampPT
+      updateNameTimestamp: timestampPT
     })
   }
 
   function updateEmailFirestore(uid: string, email: string) {
     firebase.firestore().collection('users').doc(uid).update({
       email: email,
-      timestamp: timestampPT
+      updateEmailTimestamp: timestampPT
     })
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -104,17 +104,17 @@ html, body {
 
 /* pills pages - building cards and info windows */
 .address-phone-block {
-  margin-top: 1em;
-  margin-bottom: 1em;
+  margin-top: .5em;
+  margin-bottom: .5em;
 }
 
 .first-phone-num {
-  margin-top: 1em;
+  margin-top: .5em;
   margin-bottom: 0em;
 }
 
 .table {
-  margin-top: 1em;
+  margin-top: .5em;
   margin-bottom: 0em;
 }
 /* pills pages - end of building cards and info windows */

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,7 @@ html, body {
 
 .navbar .nav-link, .navbar-text {
   color: black !important;
+  border-radius: 10%
 }
 
 .navbar .nav-link:hover {

--- a/src/interfaces/ISavedBuilding.ts
+++ b/src/interfaces/ISavedBuilding.ts
@@ -2,4 +2,5 @@ import IBuilding from "./IBuilding";
 
 export default interface ISavedBuilding extends IBuilding{
   note?: string;
+  noteTimestamp?: string;
 }

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -4,6 +4,7 @@ import logging from '../config/logging';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Container, Form, Button } from "react-bootstrap"
 import firebase from "../db/firebase";
+import { timestampPT } from '../utils/generalUtils';
 
 const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = props => {
 
@@ -27,7 +28,7 @@ const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = p
       subject: formFields.subject,
       description: formFields.description,
       message: formFields.message,
-      timestamp: new Date().toUTCString()
+      timestamp: timestampPT
     })
     .then(() => {
       console.log('Message successfully submitted!');

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -28,7 +28,7 @@ const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = p
       subject: formFields.subject,
       description: formFields.description,
       message: formFields.message,
-      sentTimestamp: timestampPT
+      sentTimestamp: timestampPT()
     })
     .then(() => {
       console.log('Message successfully submitted!');

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -28,7 +28,7 @@ const ContactPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = p
       subject: formFields.subject,
       description: formFields.description,
       message: formFields.message,
-      timestamp: timestampPT
+      sentTimestamp: timestampPT
     })
     .then(() => {
       console.log('Message successfully submitted!');

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -46,7 +46,7 @@ export function saveBuilding(currentUser: any, building: IBuilding) {
     "zip": zip,
     "lat": lat,
     "lng": lng,
-    "savedTimestamp": timestampPT
+    "savedTimestamp": timestampPT()
   })
   .then(() => {
     console.log(`${buildingName} saved to user list`);
@@ -70,3 +70,17 @@ export function deleteBuilding(currentUser: any, buildingID: string, buildingNam
     });
   });
 };
+
+export function updateNameFirestore(uid: string, name: string) {
+  return firebase.firestore().collection('users').doc(uid).update({
+    name: name,
+    updateNameTimestamp: timestampPT()
+  });
+}
+
+export function updateEmailFirestore(uid: string, email: string) {
+  return firebase.firestore().collection('users').doc(uid).update({
+    email: email,
+    updateEmailTimestamp: timestampPT()
+  });
+}

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -1,5 +1,6 @@
 import firebase from "../db/firebase";
 import IBuilding from "../interfaces/IBuilding";
+import { timestampPT } from "./generalUtils";
 
 export function saveBuilding(currentUser: any, building: IBuilding) {
   const {
@@ -45,6 +46,7 @@ export function saveBuilding(currentUser: any, building: IBuilding) {
     "zip": zip,
     "lat": lat,
     "lng": lng,
+    "savedTimestamp": timestampPT
   })
   .then(() => {
     console.log(`${buildingName} saved to user list`);

--- a/src/utils/generalUtils.ts
+++ b/src/utils/generalUtils.ts
@@ -1,4 +1,6 @@
-export const timestampPT = new Date().toLocaleString("en-US", {
-  timeZone: "America/Los_Angeles",
-  timeZoneName: "shortGeneric" 
-});
+export function timestampPT() {
+  return new Date().toLocaleString("en-US", {
+    timeZone: "America/Los_Angeles",
+    timeZoneName: "shortGeneric"
+  });
+}

--- a/src/utils/generalUtils.ts
+++ b/src/utils/generalUtils.ts
@@ -1,0 +1,4 @@
+export const timestampPT = new Date().toLocaleString("en-US", {
+  timeZone: "America/Los_Angeles",
+  timeZoneName: "shortGeneric" 
+});


### PR DESCRIPTION
**Added ability to update user name in Profile Update**
- Noticed we can store displayName property in firebase auth! Added it and now getting name data is simpler. (We still also save name and email to firestore.)
- Added timestamp to sign up, name update, email update

**Improved Saved Homes note form**
- Button is now disabled when there is not a new note to add (form either empty or text same as before)
- Added timestamp
- TODO for later: Name/email don't update in the navbar or in the profile until user navigates away from profile (profile) or refreshes the app (navbar). We never had this functionality.

**General**
- Added timestampPT util
- reduced spacing for building contact