### PR TITLE
Small improvements to reset password modal

### DIFF
--- a/src/auth_components/PasswordReset.tsx
+++ b/src/auth_components/PasswordReset.tsx
@@ -21,7 +21,7 @@ export default function PasswordReset({ onLoginClicked, onSignupClicked }: Props
       setError("");
       setLoading(true);
       await resetPassword(emailRef.current.value);
-      setMessage("Please check your inbox for further instructions.");
+      setMessage("Please check your inbox for the reset link.");
     } catch (error: any) {
       console.log(error.code);
       console.log(error.message);

--- a/src/auth_components/PasswordReset.tsx
+++ b/src/auth_components/PasswordReset.tsx
@@ -21,9 +21,11 @@ export default function PasswordReset({ onLoginClicked, onSignupClicked }: Props
       setError("");
       setLoading(true);
       await resetPassword(emailRef.current.value);
-      setMessage("Check your inbox for further instructions");
-    } catch {
-      setError("Failed to reset password");
+      setMessage("Please check your inbox for further instructions.");
+    } catch (error: any) {
+      console.log(error.code);
+      console.log(error.message);
+      setError(error.message);
     }
 
     setLoading(false);


### PR DESCRIPTION
**Changes summary:**
- This PR improves error and success messaging (alerts) for resetting password (minor changes).
- Initially, was looking into reset password because the links sent were marked as expired. The issue turned out to be that the required url wasn't in the allowed urls for the API key so I fixed that in Google Console and the issue is solved 🎉