### PR TITLE
Added logging on page load where missing, small routes refactor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import PrivateRoute from "./auth_components/PrivateRoute";
-
 import logging from "./config/logging";
-import routes from "./config/routes";
+
+import privateRoutes from "./config/privateRoutes";
+import publicRoutes from "./config/publicRoutes";
 
 import { Header } from "./components/Navbar";
 import { Footer } from "./components/Footer";
@@ -12,9 +13,6 @@ import {
   Switch,
   RouteComponentProps,
 } from "react-router-dom";
-
-import ManageProfile from "./pages/ManageProfile";
-import SavedBuildings from "./pages/SavedBuildings";
 
 import { AuthProvider } from "./contexts/AuthContext";
 import { ModalContext, ModalState } from "./contexts/ModalContext";
@@ -33,20 +31,22 @@ const Application: React.FunctionComponent<{}> = (props) => {
           <ModalContext.Provider value={modalStateHook}>
             <Header />
             <Switch>
-              <PrivateRoute
-                exact
-                path="/manage-profile"
-                component={ManageProfile}
-              />
-              <PrivateRoute
-                exact
-                path="/saved-buildings"
-                component={SavedBuildings}
-              />
-              {routes.map((route, index) => {
+              {privateRoutes.map((route) => {
+                return (
+                  <PrivateRoute
+                    key={route.name}
+                    path={route.path}
+                    exact={route.exact}
+                    component={route.component}
+                    name={route.name}
+                  />
+                );
+              })}
+
+              {publicRoutes.map((route) => {
                 return (
                   <Route
-                    key={index}
+                    key={route.name}
                     path={route.path}
                     exact={route.exact}
                     render={(props: RouteComponentProps<any>) => (

--- a/src/auth_components/PrivateRoute.tsx
+++ b/src/auth_components/PrivateRoute.tsx
@@ -6,9 +6,8 @@ export default function PrivateRoute({ component: Component, ...rest }: any) {
 
   return (
     <Route
-      {...rest}
-      render={(props) => {
-        return currentUser ? <Component {...props} /> : <Redirect to="#" />;
+      render={() => {
+        return currentUser ? <Component {...rest} /> : <Redirect to="#" />;
       }}
     ></Route>
   );

--- a/src/config/privateRoutes.ts
+++ b/src/config/privateRoutes.ts
@@ -1,0 +1,21 @@
+import IRoute from "../interfaces/IRoute";
+
+import ManageProfilePage from "../pages/ManageProfile";
+import SavedBuildingsPage from "../pages/SavedBuildings";
+
+const privateRoutes: IRoute[] = [
+  {
+    path: "/saved-buildings",
+    name: "Saved Buildings Page",
+    component: SavedBuildingsPage,
+    exact: true,
+  },
+  {
+    path: "/manage-profile",
+    name: "Manage Profile Page",
+    component: ManageProfilePage,
+    exact: true,
+  },
+];
+
+export default privateRoutes;

--- a/src/config/publicRoutes.ts
+++ b/src/config/publicRoutes.ts
@@ -1,14 +1,12 @@
-import AboutPage from "../pages/About";
-import AllBuildingsPage from "../pages/AllBuildings";
 import IRoute from "../interfaces/IRoute";
 
+import AboutPage from "../pages/About";
+import AllBuildingsPage from "../pages/AllBuildings";
 import ContactPage from "../pages/Contact";
 import HomePage from "../pages/Home";
-import ManageProfilePage from "../pages/ManageProfile";
 import ResourcesPage from "../pages/Resources";
-import SavedBuildingsPage from "../pages/SavedBuildings";
 
-const routes: IRoute[] = [
+const publicRoutes: IRoute[] = [
   {
     path: "/",
     name: "Home Page",
@@ -40,18 +38,6 @@ const routes: IRoute[] = [
     exact: true,
   },
   {
-    path: "/saved-buildings",
-    name: "Saved Buildings Page",
-    component: SavedBuildingsPage,
-    exact: true,
-  },
-  {
-    path: "/manage-profile",
-    name: "Manage Profile Page",
-    component: ManageProfilePage,
-    exact: true,
-  },
-  {
     path: "*",
     name: "Home Page",
     component: HomePage,
@@ -59,4 +45,4 @@ const routes: IRoute[] = [
   },
 ];
 
-export default routes;
+export default publicRoutes;

--- a/src/pages/AllBuildings.tsx
+++ b/src/pages/AllBuildings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
+import logging from "../config/logging";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import "firebase/firestore";
 import { useSavedBuildings } from "../hooks/useSavedBuildings";
@@ -27,7 +28,11 @@ const ref = getAllBuildingsRef();
 
 const AllBuildingsPage: React.FunctionComponent<
   IPage & RouteComponentProps<any>
-> = () => {
+> = (props) => {
+  useEffect(() => {
+    logging.info(`Loading ${props.name}`);
+  }, [props.name]);
+
   const [allBuildings, setAllBuildings] = useState([] as Array<IBuilding>);
   const [loading, setLoading] = useState(false);
 

--- a/src/pages/ManageProfile.tsx
+++ b/src/pages/ManageProfile.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import logging from "../config/logging";
 import { useAuth } from "../contexts/AuthContext";
 import UpdateProfile from "../auth_components/UpdateProfile";
 import Profile from "../components/Profile";
@@ -12,7 +14,11 @@ import Tab from "react-bootstrap/Tab";
 
 const ManageProfilePage: React.FunctionComponent<
   IPage & RouteComponentProps<any>
-> = () => {
+> = (props) => {
+  useEffect(() => {
+    logging.info(`Loading ${props.name}`);
+  }, [props.name]);
+
   const { currentUser } = useAuth() as any;
 
   if (!currentUser) {

--- a/src/pages/SavedBuildings.tsx
+++ b/src/pages/SavedBuildings.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import logging from "../config/logging";
 import { useAuth } from "../contexts/AuthContext";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { useSavedBuildings } from "../hooks/useSavedBuildings";
@@ -15,7 +17,11 @@ import Spinner from "react-bootstrap/Spinner";
 
 const SavedBuildingsPage: React.FunctionComponent<
   IPage & RouteComponentProps<any>
-> = () => {
+> = (props) => {
+  useEffect(() => {
+    logging.info(`Loading ${props.name}`);
+  }, [props.name]);
+
   const { currentUser } = useAuth() as any;
   const [savedBuildings, loading] = useSavedBuildings();
 


### PR DESCRIPTION
This came about when I noticed that we nicely log what page is loading in the console for most pages, but not all.
The logging helped me see that we actually reload the app when the MFTE Map **link** is clicked (not in the navbar, but the 2 links from About and Saved pages). Going to have a follow up PR to fix that.

**Changes summary:**
- Separated public and private routes - instead of one routes config file, we now have a privateRoutes and a publicRoutes file. Some refactoring around this.
- Added on page load logging for MFTE Map page (public), Profile page (private), and Saved page (private).
- Minor import order/spacing update.