### PR TITLE
Fixed rerendering of app upon MFTE Map link click

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import logging from "../config/logging";
-import { RouteComponentProps, withRouter } from "react-router-dom";
+import { Link, RouteComponentProps, withRouter } from "react-router-dom";
 import IPage from "../interfaces/IPage";
 
 import Col from "react-bootstrap/Col";
@@ -84,9 +84,9 @@ const AboutPage: React.FunctionComponent<IPage & RouteComponentProps<any>> = (
                 number of bedrooms, neighborhood, and building name). Create a
                 free login to keep a short list of properties, view a
                 personalized map, and add notes. Explore the&nbsp;
-                <a id="Buildings_tab" href="./all-buildings">
+                <Link id="all-buildings" to="./all-buildings">
                   MFTE map
-                </a>
+                </Link>
                 &nbsp;to get started.
               </div>
             </Col>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import logging from "../config/logging";
-import { useHistory } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import IPage from "../interfaces/IPage";
 
 import Button from "react-bootstrap/Button";
@@ -33,9 +33,9 @@ const HomePage: React.FunctionComponent<IPage> = (props) => {
           </p>
           <p className="lead">
             View participating buildings on the&nbsp;
-            <a id="Buildings_tab" href="./all-buildings">
+            <Link id="all-buildings" to="./all-buildings">
               MFTE map
-            </a>
+            </Link>
             . Create an account to save buildings and keep notes. Contact
             buildings directly for current availability.
           </p>

--- a/src/pages/SavedBuildings.tsx
+++ b/src/pages/SavedBuildings.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "../contexts/AuthContext";
-import { RouteComponentProps, withRouter } from "react-router-dom";
+import { Link, RouteComponentProps, withRouter } from "react-router-dom";
 import { useSavedBuildings } from "../hooks/useSavedBuildings";
 import IPage from "../interfaces/IPage";
 
@@ -59,9 +59,9 @@ const SavedBuildingsPage: React.FunctionComponent<
                   <p>
                     Empty for now! To start your list, use the Save button on
                     the&nbsp;
-                    <a id="Buildings_tab" href="./all-buildings">
+                    <Link id="all-buildings" to="./all-buildings">
                       MFTE map
-                    </a>
+                    </Link>
                     .
                   </p>
                 </>


### PR DESCRIPTION
Noticed the MFTE Map links (there are 3 of them across pages) rerendered the app.
To fix this, replaced <a tag with React router's <Link tag.