### PR TITLE
Address data not saving to Firestore upon signup

### DIFF
--- a/src/auth_components/Login.tsx
+++ b/src/auth_components/Login.tsx
@@ -34,12 +34,16 @@ export default function Login({
         afterLogin();
       }
     } catch (error: any) {
-      console.log(error.code);
-      const userMessage =
-        error.code === "auth/wrong-password"
-          ? "Wrong password, please try again."
-          : error.message;
-      console.log(error.message);
+      console.error(error.code, error.message);
+      let userMessage = "";
+
+      if (error.code === "auth/wrong-password") {
+        userMessage = "Wrong password, please try again.";
+      } else if (error.code === "auth/user-not-found") {
+        userMessage = "Please check your username.";
+      } else {
+        userMessage = error.message;
+      }
       setMessage(userMessage);
     }
     setLoading(false);

--- a/src/auth_components/PasswordReset.tsx
+++ b/src/auth_components/PasswordReset.tsx
@@ -30,8 +30,7 @@ export default function PasswordReset({
       await resetPassword(emailRef.current.value);
       setMessage("Please check your inbox for the reset link.");
     } catch (error: any) {
-      console.log(error.code);
-      console.log(error.message);
+      console.error(error.code, error.message);
       setError(error.message);
     }
 

--- a/src/auth_components/Signup.tsx
+++ b/src/auth_components/Signup.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { signupFirestore } from "../utils/firestoreUtils";
 
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
@@ -34,17 +33,13 @@ export default function Signup({ onLoginClicked }: Props) {
     try {
       setMessage("");
       setLoading(true);
-      const user = await signup(
+      await signup(
         emailRef.current.value,
         passwordRef.current.value,
         nameRef.current.value
       );
-      if (user) {
-        signupFirestore(user.uid, user.email, user.displayName);
-      }
     } catch (error: any) {
-      console.log(error.code);
-      console.log(error.message);
+      console.log(`${error.code}: ${error.message}`);
       setMessage(error.message);
     }
     setLoading(false);

--- a/src/auth_components/Signup.tsx
+++ b/src/auth_components/Signup.tsx
@@ -39,7 +39,7 @@ export default function Signup({ onLoginClicked }: Props) {
         nameRef.current.value
       );
     } catch (error: any) {
-      console.log(`${error.code}: ${error.message}`);
+      console.error(error.code, error.message);
       setMessage(error.message);
     }
     setLoading(false);

--- a/src/auth_components/UpdateProfile.tsx
+++ b/src/auth_components/UpdateProfile.tsx
@@ -84,7 +84,7 @@ export default function UpdateProfile() {
       .then(() => {
         // Auth is the source of truth for name/email/password
         // Firestore stores name/email as well but it's still a
-        // Success for the user if Firestore update fails (unlikely)
+        // Success for the user if Firestore update fails
         setMessage("Success! Account updated.");
         console.log("Account updated in Auth.");
 
@@ -92,8 +92,8 @@ export default function UpdateProfile() {
           .then(() => {
             console.log("Account updated in Firestore.");
           })
-          .catch(() => {
-            console.log("Error updating account in Firestore.");
+          .catch((error) => {
+            console.log(`Error updating account in Firestore: ${error.code}, ${error.message}`);
           });
       })
       .catch((error) => {
@@ -147,18 +147,16 @@ export default function UpdateProfile() {
               )}
 
               <Form onSubmit={handleFormSubmit}>
-                {currentUser.displayName && (
-                  <Form.Group id="displayName" className="form-group">
-                    <Form.Label>Name</Form.Label>
-                    <Form.Control
-                      required
-                      type="displayName"
-                      ref={displayNameRef}
-                      defaultValue={currentUser.displayName}
-                      onChange={handleChange}
-                    />
-                  </Form.Group>
-                )}
+                <Form.Group id="displayName" className="form-group">
+                  <Form.Label>Name</Form.Label>
+                  <Form.Control
+                    required
+                    type="displayName"
+                    ref={displayNameRef}
+                    defaultValue={currentUser.displayName}
+                    onChange={handleChange}
+                  />
+                </Form.Group>
                 <Form.Group id="email" className="form-group">
                   <Form.Label>Email</Form.Label>
                   <Form.Control

--- a/src/auth_components/UpdateProfile.tsx
+++ b/src/auth_components/UpdateProfile.tsx
@@ -93,13 +93,13 @@ export default function UpdateProfile() {
             console.log("Account updated in Firestore.");
           })
           .catch((error) => {
-            console.log(
+            console.error(
               `Error updating account in Firestore: ${error.code}, ${error.message}`
             );
           });
       })
       .catch((error) => {
-        console.log(error.code, error.message);
+        console.error(error.code, error.message);
         setMessage(error.message);
       })
       .finally(() => {

--- a/src/auth_components/UpdateProfile.tsx
+++ b/src/auth_components/UpdateProfile.tsx
@@ -93,7 +93,9 @@ export default function UpdateProfile() {
             console.log("Account updated in Firestore.");
           })
           .catch((error) => {
-            console.log(`Error updating account in Firestore: ${error.code}, ${error.message}`);
+            console.log(
+              `Error updating account in Firestore: ${error.code}, ${error.message}`
+            );
           });
       })
       .catch((error) => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -51,7 +51,7 @@ export const Header = () => {
       history.push("/");
     } catch {
       setMessage("Failed to log out.");
-      console.log(message);
+      console.error(message);
     }
   }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState, useEffect, createContext } from "react";
 import firebase, { auth } from "../db/firebase";
 import IProps from "../interfaces/IProps";
+import { signupFirestore } from "../utils/firestoreUtils";
 
 const AuthContext = createContext({});
 
@@ -19,6 +20,7 @@ export function AuthProvider({ children }: IProps) {
       .then((cred) => {
         if (cred.user) {
           cred.user.updateProfile({ displayName: name });
+          signupFirestore(cred.user.uid, cred.user.email, name)
         }
       });
   }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -25,19 +25,21 @@ export function AuthProvider({ children }: IProps) {
       });
   }
 
-  function login(email: string, password: string) {
-    return auth.signInWithEmailAndPassword(email, password).then((cred) => {
-      if (cred.user) {
-        // Backfill user displayName from Firestore to Auth
-        // only if the displayName doesn't already exist in Auth.
-        const name = getNameFirestore(cred.user.uid);
-        if (name && !cred.user.displayName) {
-          cred.user.updateProfile({ displayName: name });
-        }
-        // Backfill missing data from Auth to Firestore.
-        signupFirestore(cred.user.uid, cred.user.email, cred.user.displayName);
+  async function login(email: string, password: string): Promise<void> {
+    const cred = await auth.signInWithEmailAndPassword(email, password);
+
+    if (cred.user) {
+      const name = await getNameFirestore(cred.user.uid);
+
+      // Backfill user displayName from Firestore to Auth
+      // only if the displayName doesn't already exist in Auth.
+      if (name && !cred.user.displayName) {
+        cred.user.updateProfile({ displayName: name });
       }
-    });
+
+      // Backfill missing data from Auth to Firestore.
+      signupFirestore(cred.user.uid, cred.user.email, cred.user.displayName);
+    }
   }
 
   function logout() {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -20,13 +20,18 @@ export function AuthProvider({ children }: IProps) {
       .then((cred) => {
         if (cred.user) {
           cred.user.updateProfile({ displayName: name });
-          signupFirestore(cred.user.uid, cred.user.email, name)
+          signupFirestore(cred.user.uid, cred.user.email, name);
         }
       });
   }
 
   function login(email: string, password: string) {
-    return auth.signInWithEmailAndPassword(email, password);
+    return auth.signInWithEmailAndPassword(email, password).then((cred) => {
+      if (cred.user) {
+        // Backfill missing data for existing account.
+        signupFirestore(cred.user.uid, cred.user.email, cred.user.displayName);
+      }
+    });
   }
 
   function logout() {

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -129,11 +129,14 @@ export function deleteUserFirestore(uid: string) {
   return firebase.firestore().collection("users").doc(uid).delete();
 }
 
-export function signupFirestore(uid: string, email: string, name: string) {
+export function signupFirestore(uid: string, email: string | null, name: string | null) {
   return firebase.firestore().collection("users").doc(uid).set({
+    uid: uid,
     email: email,
     name: name,
     signupTimestamp: timestampPT(),
+    // Since Nov 30, 2023. This is to facilitate development and search in Firestore.
+    newSignup: true,
   });
 }
 

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -129,14 +129,18 @@ export function deleteUserFirestore(uid: string) {
   return firebase.firestore().collection("users").doc(uid).delete();
 }
 
-export function signupFirestore(uid: string, email: string | null, name: string | null) {
+export function signupFirestore(
+  uid: string,
+  email: string | null,
+  name: string | null
+) {
   return firebase.firestore().collection("users").doc(uid).set({
     uid: uid,
     email: email,
     name: name,
-    signupTimestamp: timestampPT(),
+    signupOrBackfillTimestamp: timestampPT(),
     // Since Nov 30, 2023. This is to facilitate development and search in Firestore.
-    newSignup: true,
+    recentUser: true,
   });
 }
 

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -98,11 +98,11 @@ export function getNameFirestore(uid: string): string {
         name = doc.data()?.name;
       } else {
         // doc.data() will be undefined in this case
-        console.log("No such document!");
+        console.log(`No user in "users" with uid ${uid}`);
       }
     })
     .catch((error) => {
-      console.log("Error getting document:", error);
+      console.error("Error getting document:", error);
     });
 
   return name;

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -87,6 +87,27 @@ export function deleteBuilding(
   });
 }
 
+export function getNameFirestore(uid: string): string {
+  const docRef = firebase.firestore().collection("users").doc(uid);
+  let name = "";
+
+  docRef
+    .get()
+    .then((doc) => {
+      if (doc.exists) {
+        name = doc.data()?.name;
+      } else {
+        // doc.data() will be undefined in this case
+        console.log("No such document!");
+      }
+    })
+    .catch((error) => {
+      console.log("Error getting document:", error);
+    });
+
+  return name;
+}
+
 export function updateNameFirestore(uid: string, name: string) {
   return firebase.firestore().collection("users").doc(uid).update({
     name: name,

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -87,25 +87,21 @@ export function deleteBuilding(
   });
 }
 
-export function getNameFirestore(uid: string): string {
+export function getNameFirestore(uid: string): Promise<string> {
   const docRef = firebase.firestore().collection("users").doc(uid);
-  let name = "";
-
-  docRef
+  return docRef
     .get()
     .then((doc) => {
       if (doc.exists) {
-        name = doc.data()?.name;
+        return doc.data()?.name;
       } else {
-        // doc.data() will be undefined in this case
         console.log(`No user in "users" with uid ${uid}`);
+        return "";
       }
     })
     .catch((error) => {
-      console.error("Error getting document:", error);
+      console.log(`Error getting data for user ${uid}:`, error);
     });
-
-  return name;
 }
 
 export function updateNameFirestore(uid: string, name: string) {
@@ -160,7 +156,7 @@ export function signupFirestore(
     email: email,
     name: name,
     signupOrBackfillTimestamp: timestampPT(),
-    // Since Nov 30, 2023. This is to facilitate development and search in Firestore.
+    // Since Dec 8, 2023. This is to facilitate development and search in Firestore.
     recentUser: true,
   });
 }


### PR DESCRIPTION
**Fix 1:**
- Fixed bug where if name doesn't exist in Auth, there's no form field to update it. It also wouldn't display on the navbar as greeting. This is significant because the name doesn't exist in Auth a lot since we only started adding it to Auth within the last couple of months. That being said, I don't think people use this app for very long, meaning I hope they find an apartment quickly.
- Added code to backfill Auth displayName on login going forward.

**Fix 2:**
- Fixed Firestore signup bug where user signup data was only getting saved to Auth (not Firestore). No visible impact to users and has been live for 3 days. Result was no record of the user in Firestore until they save building (which had no issues). Guilty PR: #63
- Added code to backfill Firestore data on login to address data lost.