### PR TITLE
Listings feature: Added 2 different color markers and an isAdvertisingOn flag

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,4 +4,6 @@ const config = {
   },
 };
 
+export const isAdvertisingOn = false;
+
 export default config;

--- a/src/interfaces/IBuilding.ts
+++ b/src/interfaces/IBuilding.ts
@@ -18,4 +18,5 @@ export default interface IBuilding {
   city: string;
   state: string;
   zip: string;
+  hasAd: boolean;
 }

--- a/src/map/BuildingMarker.tsx
+++ b/src/map/BuildingMarker.tsx
@@ -11,6 +11,7 @@ import {
 } from "../components/BuildingContactInfo";
 import IBuilding from "../interfaces/IBuilding";
 import Button from "react-bootstrap/Button";
+import { isAdvertisingOn } from "../config/config";
 
 interface IBuildingMarkerProps {
   building: IBuilding;
@@ -40,6 +41,7 @@ export function BuildingMarker(props: IBuildingMarkerProps) {
     phone2,
     lat,
     lng,
+    hasAd,
   } = building;
 
   const onMarkerClick = useCallback(
@@ -68,6 +70,30 @@ export function BuildingMarker(props: IBuildingMarkerProps) {
     }
   }
 
+  const svgMarkerNoAd = {
+    path: "M0 0q2.906 0 4.945 2.039t2.039 4.945q0 1.453-0.727 3.328t-1.758 3.516-2.039 3.070-1.711 2.273l-0.75 0.797q-0.281-0.328-0.75-0.867t-1.688-2.156-2.133-3.141-1.664-3.445-0.75-3.375q0-2.906 2.039-4.945t4.945-2.039z",
+    fillColor: "blue",
+    strokeColor: "black",
+    strokeWeight: 1,
+    fillOpacity: 0.8,
+    rotation: 0,
+    scale: 1.25,
+    anchor: new google.maps.Point(0, 20),
+  };
+
+  const svgMarkerAd = {
+    path: "M0 0q2.906 0 4.945 2.039t2.039 4.945q0 1.453-0.727 3.328t-1.758 3.516-2.039 3.070-1.711 2.273l-0.75 0.797q-0.281-0.328-0.75-0.867t-1.688-2.156-2.133-3.141-1.664-3.445-0.75-3.375q0-2.906 2.039-4.945t4.945-2.039z",
+    fillColor: "red",
+    strokeColor: "black",
+    strokeWeight: 1,
+    fillOpacity: 1,
+    rotation: 0,
+    scale: 1.25,
+    anchor: new google.maps.Point(0, 20),
+  };
+
+  const icon = isAdvertisingOn && hasAd ? svgMarkerAd : svgMarkerNoAd;
+
   return (
     <Marker
       position={{
@@ -75,6 +101,7 @@ export function BuildingMarker(props: IBuildingMarkerProps) {
         lng: lng,
       }}
       onClick={onMarkerClick}
+      icon={icon}
     >
       {isSelected && (
         <InfoWindow onCloseClick={clearSelection}>


### PR DESCRIPTION
This is the beginning of a feature for buildings to be able to advertise their listings.
Currently behind an `isAdvertisingOn` flag which is set to `false`, since a few features need to be added before this goes live.
<img width="558" alt="Screen Shot 2024-06-07 at 8 32 13 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/1352bc89-1ee1-42a4-8adc-aed889cf83d1">
