### PR TITLE
Pin color change

### DIFF
--- a/src/map/BuildingMarker.tsx
+++ b/src/map/BuildingMarker.tsx
@@ -72,7 +72,7 @@ export function BuildingMarker(props: IBuildingMarkerProps) {
 
   const svgMarkerNoAd = {
     path: "M0 0q2.906 0 4.945 2.039t2.039 4.945q0 1.453-0.727 3.328t-1.758 3.516-2.039 3.070-1.711 2.273l-0.75 0.797q-0.281-0.328-0.75-0.867t-1.688-2.156-2.133-3.141-1.664-3.445-0.75-3.375q0-2.906 2.039-4.945t4.945-2.039z",
-    fillColor: "blue",
+    fillColor: "#10345c",
     strokeColor: "black",
     strokeWeight: 1,
     fillOpacity: 0.8,


### PR DESCRIPTION
This is cuter:
<img width="409" alt="Screen Shot 2024-06-13 at 4 56 03 PM" src="https://github.com/anyatokar/mfte-seattle/assets/61166946/1a712d90-81f0-42c0-b9df-45bcbcb767d1">

Previously, it was url blue