### PR TITLE
Fixed search to take full street address

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -21,7 +21,7 @@ export default function SearchInput(props: ISearchProps) {
   return (
     <Form onSubmit={(event) => event.preventDefault()}>
       <Form.Label htmlFor="search" className="mt-3">
-        Search by neighborhood, address, building name, or zip code:
+        Search by neighborhood, street address, building name, or zip code:
       </Form.Label>
       <Form.Control
         id="search"

--- a/src/interfaces/IBuilding.ts
+++ b/src/interfaces/IBuilding.ts
@@ -18,4 +18,5 @@ export default interface IBuilding {
   city: string;
   state: string;
   zip: string;
+  streetAddress: string;
 }

--- a/src/pages/AllBuildings.tsx
+++ b/src/pages/AllBuildings.tsx
@@ -73,8 +73,7 @@ const AllBuildingsPage: React.FunctionComponent<
           [
             "buildingName",
             "residentialTargetedArea",
-            "streetNum",
-            "street",
+            "streetAddress",
             "zip",
           ],
           searchQuery


### PR DESCRIPTION
Before, could search by street num OR street name
Now, can search by any part of street num and name (or the whole thing)
Also, it's convenient for the database to have the full street address
The split apart version is still needed for google maps API