### PR TITLE
AMI order bug fix

### DIFF
--- a/src/components/BuildingCard.tsx
+++ b/src/components/BuildingCard.tsx
@@ -55,7 +55,7 @@ const BuildingCard: React.FC<BuildingCardProps> = (props) => {
     city,
     state,
     zip,
-    amiData,
+    // amiData,
   } = props.building;
 
   const { pageType, listing } = props;

--- a/src/components/BuildingCard.tsx
+++ b/src/components/BuildingCard.tsx
@@ -236,11 +236,11 @@ const BuildingCard: React.FC<BuildingCardProps> = (props) => {
                 />
               </div>
             </Tab>
-            {amiData && (
+            {/* {amiData && (
               <Tab eventKey="details" title="Details">
                 <BuildingDataTable type={tableType.amiData} data={amiData} />
               </Tab>
-            )}
+            )} */}
           </Tabs>
         </ListGroup.Item>
         {pageType === pageTypeEnum.savedBuildings && (

--- a/src/components/BuildingDataTable.tsx
+++ b/src/components/BuildingDataTable.tsx
@@ -32,7 +32,9 @@ const BuildingDataTable: React.FC<BuildingDataTableProps> = ({
 
   const dataHeader = type === tableType.amiData ? "% of AMI" : "# Available";
 
-  function renderPercentageList(percentages: amiPercentageType[]): React.ReactNode {
+  function renderPercentageList(
+    percentages: amiPercentageType[]
+  ): React.ReactNode {
     if (!percentages) return null;
 
     return percentages.map((item, index) => (
@@ -62,9 +64,7 @@ const BuildingDataTable: React.FC<BuildingDataTableProps> = ({
             return (
               <tr key={unitSize}>
                 <td>{unitLabels[unitSize]}</td>
-                <td>
-                  {renderPercentageList(amiPercentages)}
-                </td>
+                <td>{renderPercentageList(amiPercentages)}</td>
               </tr>
             );
           })}

--- a/src/components/BuildingDataTable.tsx
+++ b/src/components/BuildingDataTable.tsx
@@ -1,14 +1,14 @@
 import { Fragment } from "react";
 import { tableType } from "../types/enumTypes";
 
-import { AMIPercentage, amiDataType } from "../interfaces/IBuilding";
+import { amiPercentageType, amiDataType } from "../interfaces/IBuilding";
 import { availDataType } from "../interfaces/IListing";
 
 import Table from "react-bootstrap/Table";
 
 interface AmiDataProps {
   type: "amiData";
-  data: amiDataType;
+  data: amiDataType[];
 }
 
 interface AvailDataProps {
@@ -32,7 +32,7 @@ const BuildingDataTable: React.FC<BuildingDataTableProps> = ({
 
   const dataHeader = type === tableType.amiData ? "% of AMI" : "# Available";
 
-  function renderPercentageList(percentages: AMIPercentage[]): React.ReactNode {
+  function renderPercentageList(percentages: amiPercentageType[]): React.ReactNode {
     if (!percentages) return null;
 
     return percentages.map((item, index) => (
@@ -54,15 +54,16 @@ const BuildingDataTable: React.FC<BuildingDataTableProps> = ({
       </thead>
       <tbody>
         {type === tableType.amiData &&
-          Object.entries(data).map(([key, value]) => {
-            if (!value) return null;
+          data.map((amiData: amiDataType) => {
+            if (!amiData) return null;
+
+            const { unitSize, amiPercentages } = amiData;
+
             return (
-              <tr key={key}>
-                <td>{unitLabels[key]}</td>
+              <tr key={unitSize}>
+                <td>{unitLabels[unitSize]}</td>
                 <td>
-                  {type === tableType.amiData
-                    ? renderPercentageList(value)
-                    : value}
+                  {renderPercentageList(amiPercentages)}
                 </td>
               </tr>
             );

--- a/src/interfaces/IBuilding.ts
+++ b/src/interfaces/IBuilding.ts
@@ -1,13 +1,11 @@
 import { Timestamp } from "firebase/firestore";
+import { unitSizeType } from "./IListing";
 
-export type AMIPercentage = 30 | 40 | 50 | 60 | 65 | 70 | 75 | 80 | 85 | 90;
+export type amiPercentageType = 30 | 40 | 50 | 60 | 65 | 70 | 75 | 80 | 85 | 90;
 
 export type amiDataType = {
-  micro: AMIPercentage[];
-  studio: AMIPercentage[];
-  oneBed: AMIPercentage[];
-  twoBed: AMIPercentage[];
-  threePlusBed: AMIPercentage[];
+  unitSize: unitSizeType;
+  amiPercentages: amiPercentageType[];
 };
 
 export default interface IBuilding {
@@ -34,5 +32,6 @@ export default interface IBuilding {
   zip: string;
   updatedTimestamp: Timestamp;
   streetAddress: string;
-  amiData: amiDataType;
+  /** This is an array to keep the order from smallest to largest on render. */
+  amiData: amiDataType[];
 }

--- a/src/interfaces/IListing.ts
+++ b/src/interfaces/IListing.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from "firebase/firestore";
 
-type unitSizeType = "micro" | "studio" | "oneBed" | "twoBed" | "threePlusBed";
+export type unitSizeType = "micro" | "studio" | "oneBed" | "twoBed" | "threePlusBed";
 
 export type availDataType = {
   unitSize: unitSizeType;

--- a/src/interfaces/IListing.ts
+++ b/src/interfaces/IListing.ts
@@ -1,6 +1,11 @@
 import { Timestamp } from "firebase/firestore";
 
-export type unitSizeType = "micro" | "studio" | "oneBed" | "twoBed" | "threePlusBed";
+export type unitSizeType =
+  | "micro"
+  | "studio"
+  | "oneBed"
+  | "twoBed"
+  | "threePlusBed";
 
 export type availDataType = {
   unitSize: unitSizeType;

--- a/src/map/ReactMap.tsx
+++ b/src/map/ReactMap.tsx
@@ -14,7 +14,7 @@ import IMap from "../interfaces/IMap";
 
 const containerStyle = {
   width: "100%",
-  height: "80vh",
+  height: "95vh",
 };
 
 const center = {
@@ -80,7 +80,7 @@ const ReactMap: React.FC<IMap> = ({
     <GoogleMap
       mapContainerStyle={containerStyle}
       center={center}
-      zoom={14}
+      zoom={12.5}
       ref={mapRef}
       options={{ mapId: "c8d48b060a22a457" }}
     >

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -246,12 +246,3 @@ export async function signupFirestore(
     recentUser: true,
   });
 }
-
-export async function getAllBuildingsRef() {
-  return await getDocs(collection(db, "buildings"));
-}
-
-export async function getSavedBuildingsRef(uid: string) {
-  const userDocRef = doc(db, "users", uid);
-  return await getDocs(collection(userDocRef, "savedHomes"));
-}

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -3,7 +3,6 @@ import {
   collection,
   deleteDoc,
   getDoc,
-  getDocs,
   doc,
   setDoc,
   updateDoc,


### PR DESCRIPTION
This is a small bug - fixes Details not rendering in order. It needs data to be re-uploaded though with a new structure. Temporarily comments out Details tab code to avoid runtime errors.
1) test again
2) replace buildings data
3) merge this in

Before:
<img width="385" alt="Screen Shot 2024-09-26 at 12 39 11 PM" src="https://github.com/user-attachments/assets/8485eb2f-0ba7-4aed-8d12-b7d6ba27339a">

After:
<img width="360" alt="Screen Shot 2024-09-26 at 12 41 22 PM" src="https://github.com/user-attachments/assets/ff974074-e6e0-4d11-9744-6b1293e1a9b1">

