### PR TITLE
Improved button and tabs style, updated resources page

### DIFF
--- a/src/components/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter.tsx
@@ -120,7 +120,7 @@ const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
                 </Form>
               </Dropdown.Menu>
             </Dropdown>
-            <Form>
+            <Form className="d-flex align-items-center">
               <KnownAvailSwitch onCheckboxChange={onAvailOnlyToggle} />
             </Form>
           </Stack>

--- a/src/components/checkboxes/KnownAvailSwitch.tsx
+++ b/src/components/checkboxes/KnownAvailSwitch.tsx
@@ -16,13 +16,17 @@ const KnownAvailSwitch: React.FC<KnownAvailSwitchProps> = ({
   }
 
   return (
-    <Form.Check
-      type="switch"
-      id="custom-switch"
-      label={"Known Availability"}
-      checked={isSwitchOn}
-      onChange={handleCheck}
-    />
+    <>
+      <Form.Check
+        type="switch"
+        id="availability-switch"
+        checked={isSwitchOn}
+        onChange={handleCheck}
+      />
+      <Form.Label htmlFor="custom-switch" className="mb-0">
+        Known Availability
+      </Form.Label>
+    </>
   );
 };
 

--- a/src/pages/AllBuildings.tsx
+++ b/src/pages/AllBuildings.tsx
@@ -207,14 +207,14 @@ const AllBuildingsPage: React.FC<IPage> = () => {
         {/* Only visible on small screens */}
         <Container fluid className="d-block d-md-none">
           <Tab.Container id="sidebar" defaultActiveKey="map">
-            <Nav variant="pills" className="mb-2">
+            <Nav variant="pills" className="mb-2 small">
               <Nav.Item>
-                <Nav.Link eventKey="map" className="tab">
+                <Nav.Link eventKey="map" className="tab small py-1 px-2">
                   Map View
                 </Nav.Link>
               </Nav.Item>
               <Nav.Item>
-                <Nav.Link eventKey="list" className="tab">
+                <Nav.Link eventKey="list" className="tab small py-1 px-2">
                   List View
                 </Nav.Link>
               </Nav.Item>

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -36,94 +36,92 @@ const ResourcesPage: React.FC<IPage> = () => {
           <Col lg={10} xl={8}>
             <div className="display-6 mb-5">Resources</div>
 
-            <ListGroup>
-              <ListGroup.Item>
+            <ListGroup variant="flush">
+              <ListGroup.Item style={{ background: "none" }}>
+                <div className="fw-light">
+                  Seattle Office of Housing homepage with contact information.
+                </div>
                 <a
                   id="seattle-housing-website"
                   href="https://seattle.gov/housing"
                   title="https://seattle.gov/housing"
                   target="_blank"
                   rel="noreferrer"
-                  className="fw-bold"
                 >
                   Seattle Office of Housing
                 </a>
-                <div className="fw-light">
-                  Seattle Office of Housing homepage with contact information.
-                </div>
+
                 <div className="fw-light">website — City of Seattle</div>
               </ListGroup.Item>
 
-              <ListGroup.Item>
+              <ListGroup.Item style={{ background: "none" }}>
+                <div className="fw-light">
+                  Information about the MFTE program and other income and
+                  rent-restricted properties.
+                </div>
                 <a
                   id="mfte-city-website-renters"
                   href="https://www.seattle.gov/housing/renters/find-housing#affordableapartmentsinmarketratebuildings"
                   title="https://www.seattle.gov/housing/renters/find-housing#affordableapartmentsinmarketratebuildings"
                   target="_blank"
                   rel="noreferrer"
-                  className="fw-bold"
                 >
                   MFTE Main Resources Page
                 </a>
-                <div className="fw-light">
-                  Information about the MFTE program and other income and
-                  rent-restricted properties.
-                </div>
+
                 <div className="fw-light">website — City of Seattle</div>
               </ListGroup.Item>
 
-              <ListGroup.Item>
+              <ListGroup.Item style={{ background: "none" }}>
+                <div className="fw-light">
+                  Market-Rate Rental Properties with Affordable Housing Units
+                  spreadsheet.
+                </div>
                 <a
                   id="properties-spreadsheet-april-2024"
                   href="https://www.seattle.gov/documents/Departments/Housing/Renters/Affordable_Rental_Housing_MFTE-MHA-IZ.pdf"
                   title="https://www.seattle.gov/documents/Departments/Housing/Renters/Affordable_Rental_Housing_MFTE-MHA-IZ.pdf"
                   target="_blank"
                   rel="noreferrer"
-                  className="fw-bold"
                 >
                   MFTE Spreadsheet of Buildings
                 </a>
-                <div className="fw-light">
-                  Market-Rate Rental Properties with Affordable Housing Units
-                  spreadsheet.
-                </div>
+
                 <div className="fw-light">
                   PDF — City of Seattle — April 2024
                 </div>
               </ListGroup.Item>
 
-              <ListGroup.Item>
+              <ListGroup.Item style={{ background: "none" }}>
                 <a
                   id="income-and-rent-limits"
                   href="https://www.seattle.gov/documents/Departments/Housing/PropertyManagers/IncomeRentLimits/2024/2024_RentIncomeLimits_5.28.24.pdf"
                   title="https://www.seattle.gov/documents/Departments/Housing/PropertyManagers/IncomeRentLimits/2024/2024_RentIncomeLimits_5.28.24.pdf"
                   target="_blank"
                   rel="noreferrer"
-                  className="fw-bold"
                 >
                   Income and Rent Limits (FY 2024)
                 </a>
-                <div></div>
+
                 <div className="fw-light">
                   PDF — City of Seattle — April 22, 2024
                 </div>
               </ListGroup.Item>
 
-              <ListGroup.Item>
+              <ListGroup.Item style={{ background: "none" }}>
+                <div className="fw-light">
+                  Renters' Guide for Market-Rate Apartment Buildings with
+                  Affordable Units.
+                </div>
                 <a
                   id="renters-guide"
                   href="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Renters_Guide_7-2023.pdf"
                   title="https://www.seattle.gov/documents/Departments/Housing/Renters/Incentive_Programs_Renters_Guide_7-2023.pdf"
                   target="_blank"
                   rel="noreferrer"
-                  className="fw-bold"
                 >
                   Detailed Renters' Guide
                 </a>
-                <div className="fw-light">
-                  Renters' Guide for Market-Rate Apartment Buildings with
-                  Affordable Units.
-                </div>
                 <div className="fw-light">
                   PDF — City of Seattle — July 2023
                 </div>


### PR DESCRIPTION
**Before**
<img width="409" alt="Screen Shot 2025-02-18 at 5 11 36 PM" src="https://github.com/user-attachments/assets/2c5c5ec3-4e17-4581-af1f-78e9e0c529e4" />

**After**
<img width="408" alt="Screen Shot 2025-02-18 at 5 14 08 PM" src="https://github.com/user-attachments/assets/6326a8f1-9232-47cd-a642-1511178c97e1" />
