### PR TITLE
Responsive map size

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,11 @@
     </script>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import PrivateRoute from "./auth_components/PrivateRoute";
 import { isProfilerOn } from "./config/config";
 import privateRoutes from "./config/privateRoutes";
 import publicRoutes from "./config/publicRoutes";
-import { Header } from "./components/Navbar";
+import { TopNav } from "./components/TopNav";
 import { Footer } from "./components/Footer";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
@@ -41,7 +41,7 @@ const Application: React.FC = () => {
         <BrowserRouter>
           <AuthProvider>
             <ModalContext.Provider value={modalStateHook}>
-              <Header />
+              <TopNav />
               <AllBuildingsProvider>
                 <Routes>
                   {privateRoutes.map((route) => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Profiler, useState } from "react";
+import { Profiler, useRef, useState } from "react";
 import PrivateRoute from "./auth_components/PrivateRoute";
 import { isProfilerOn } from "./config/config";
 import privateRoutes from "./config/privateRoutes";
@@ -13,6 +13,7 @@ import { ModalContext, ModalState } from "./contexts/ModalContext";
 
 const Application: React.FC = () => {
   const modalStateHook = useState(ModalState.HIDDEN);
+  const topNavRef = useRef<HTMLDivElement | null>(null);
 
   return (
     <Profiler
@@ -41,7 +42,9 @@ const Application: React.FC = () => {
         <BrowserRouter>
           <AuthProvider>
             <ModalContext.Provider value={modalStateHook}>
-              <TopNav />
+              <div ref={topNavRef} className="topnav-container">
+                <TopNav />
+              </div>
               <AllBuildingsProvider>
                 <Routes>
                   {privateRoutes.map((route) => (
@@ -60,7 +63,7 @@ const Application: React.FC = () => {
                     <Route
                       key={route.name}
                       path={route.path}
-                      element={<route.component />}
+                      element={<route.component topNavRef={topNavRef} />}
                     />
                   ))}
                 </Routes>

--- a/src/components/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter.tsx
@@ -120,7 +120,7 @@ const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
       </Row>
 
       {/* filter for small screens */}
-      <Row className="d-md-none d-flex align-items-center ">
+      <Row className="d-md-none d-flex align-items-center">
         <Col sm={7} className="mb-1">
           <Stack direction="horizontal" gap={2}>
             <NeighborhoodDropdown

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -19,7 +19,7 @@ import Modal from "react-bootstrap/Modal";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 
-export const Header = () => {
+export const TopNav = () => {
   const { currentUser, logout, accountType } = useAuth();
   const navigate = useNavigate();
   const [modalState, setModalState] = useContext(ModalContext);

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -18,6 +18,7 @@ import Image from "react-bootstrap/Image";
 import Modal from "react-bootstrap/Modal";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
+import Offcanvas from "react-bootstrap/esm/Offcanvas";
 
 export const TopNav = () => {
   const { currentUser, logout, accountType } = useAuth();
@@ -96,73 +97,86 @@ export const TopNav = () => {
     }
   }
 
+  const greeting = currentUser ? (
+    <Navbar.Text className="me-lg-4 diy-font-italic d-flex align-items-center">
+      {currentUser.displayName && `Hi, ${currentUser.displayName}!`}
+    </Navbar.Text>
+  ) : null;
+
   return (
-    <Navbar collapseOnSelect expand="lg" className="p-0">
-      <Container fluid className="p-0">
-        <LinkContainer to="/">
-          <Navbar.Brand className="py-0">
-            <Image
-              src={mftelogo}
-              height="70"
-              width="80"
-              alt="MFTE Seattle website logo: a teal map pin with a house on it"
-            />
-          </Navbar.Brand>
-        </LinkContainer>
-        <Navbar.Toggle />
-        <Navbar.Collapse>
-          <Nav className="me-auto p-0">
-            <LinkContainer to="/all-buildings">
-              <Nav.Link active={false}>MFTE Map</Nav.Link>
-            </LinkContainer>
-            <LinkContainer to="/about">
-              <Nav.Link active={false}>About</Nav.Link>
-            </LinkContainer>
-            <LinkContainer to="/resources">
-              <Nav.Link active={false}>Resources</Nav.Link>
-            </LinkContainer>
-            <Dropdown.Divider />
-            <LinkContainer to="/contact">
-              <Nav.Link active={false}>Contact</Nav.Link>
-            </LinkContainer>
-            <LinkContainer to="/for-managers">
-              <Nav.Link active={false}>For Property Managers</Nav.Link>
-            </LinkContainer>
-            <Dropdown.Divider />
-          </Nav>
-          {currentUser ? (
-            <Nav className="p-0 p-lg-3">
-              <Navbar.Text className="me-lg-4 diy-font-italic">
-                {currentUser.displayName && `Hi, ${currentUser.displayName}!`}
-              </Navbar.Text>
-              {accountType === accountTypeEnum.MANAGER && (
-                <LinkContainer to="/manage-listings">
-                  <Nav.Link active={false}>Listings</Nav.Link>
+    <>
+      <Navbar collapseOnSelect expand="lg" className="top-navbar p-0">
+        <Container fluid className="py-0">
+          <LinkContainer to="/">
+            <Navbar.Brand className="py-0">
+              <Image
+                src={mftelogo}
+                height="65"
+                width="75"
+                alt="MFTE Seattle website logo: a teal map pin with a house on it"
+              />
+            </Navbar.Brand>
+          </LinkContainer>
+          <Navbar.Toggle />
+          <Navbar.Offcanvas placement="end" className="offset-navbar">
+            <Offcanvas.Header closeButton />
+
+            <Offcanvas.Body className="d-lg-flex align-items-lg-center">
+              <Nav className="me-auto p-0">
+                <div className="d-md-none">{greeting}</div>
+                <LinkContainer to="/all-buildings">
+                  <Nav.Link active={false}>MFTE Map</Nav.Link>
                 </LinkContainer>
+                <LinkContainer to="/about">
+                  <Nav.Link active={false}>About</Nav.Link>
+                </LinkContainer>
+                <LinkContainer to="/resources">
+                  <Nav.Link active={false}>Resources</Nav.Link>
+                </LinkContainer>
+                <Dropdown.Divider />
+                <LinkContainer to="/contact">
+                  <Nav.Link active={false}>Contact</Nav.Link>
+                </LinkContainer>
+                <LinkContainer to="/for-managers">
+                  <Nav.Link active={false}>For Property Managers</Nav.Link>
+                </LinkContainer>
+                <Dropdown.Divider />
+              </Nav>
+
+              {currentUser ? (
+                <Nav className="p-0 p-lg-3">
+                  <div className="d-none d-lg-block">{greeting}</div>
+
+                  {accountType === accountTypeEnum.MANAGER && (
+                    <LinkContainer to="/manage-listings">
+                      <Nav.Link active={false}>Listings</Nav.Link>
+                    </LinkContainer>
+                  )}
+                  <LinkContainer to="/manage-profile">
+                    <Nav.Link active={false}>Profile</Nav.Link>
+                  </LinkContainer>
+                  <Nav.Link
+                    className="logout"
+                    active={false}
+                    onClick={handleLogout}
+                  >
+                    Logout
+                  </Nav.Link>
+                </Nav>
+              ) : (
+                <Nav className="p-0 p-lg-3">
+                  <Nav.Link active={false} onClick={showLogin}>
+                    Log In / Sign Up
+                  </Nav.Link>
+                  <Modal show={showModal} onHide={closeLogin}>
+                    {chooseModalComponent()}
+                  </Modal>
+                </Nav>
               )}
-              <LinkContainer to="/manage-profile">
-                <Nav.Link active={false}>Profile</Nav.Link>
-              </LinkContainer>
-              <Nav.Link
-                className="logout"
-                active={false}
-                onClick={handleLogout}
-              >
-                Logout
-              </Nav.Link>
-            </Nav>
-          ) : (
-            <Nav className="p-0 p-lg-3">
-              <Nav.Link active={false} onClick={showLogin}>
-                Log In / Sign Up
-              </Nav.Link>
-              <Modal show={showModal} onHide={closeLogin}>
-                {chooseModalComponent()}
-              </Modal>
-            </Nav>
-          )}
-        </Navbar.Collapse>
-      </Container>
-    </Navbar>
+            </Offcanvas.Body>
+          </Navbar.Offcanvas>
+        </Container>
+      </Navbar>
+    </>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body {
 .main {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  min-height: 100vdh; /* dynamically adjusts to viewport changes (when mobile browser bars appear/disappear) */
 }
 /* end of entire app */
 

--- a/src/index.css
+++ b/src/index.css
@@ -12,26 +12,36 @@ body {
 /* end of entire app */
 
 /* navbar section */
-.navbar {
-  background: white;
+.top-navbar {
+  background: white !important;
   text-align: center;
 }
 
-.navbar-brand {
+/* For screens smaller than lg (992px) */
+@media (max-width: 991.98px) {
+  .offset-navbar {
+    width: 13em !important;
+  }
+}
+
+.top-navbar-brand {
   margin-left: 0.5em;
 }
 
-.navbar-toggler {
+.top-navbar-toggler {
   margin-right: 0.5em;
 }
 
-.navbar .nav-link {
+.offset-navbar .nav-link,
+.top-navbar .nav-link {
   color: black !important;
   text-decoration: none;
   position: relative;
   display: inline-block;
 }
 
+.offset-navbar .nav-link:hover,
+.offset-navbar .nav-link.active,
 .navbar .nav-link:hover,
 .navbar .nav-link.active {
   text-decoration: underline;

--- a/src/index.css
+++ b/src/index.css
@@ -16,7 +16,6 @@ body {
   background: white;
   text-align: center;
 }
-/* navbar section */
 
 .navbar-brand {
   margin-left: 0.5em;
@@ -41,6 +40,7 @@ body {
   text-decoration-color: #51b7c8;
   transition: text-decoration-color 0.4s ease;
 }
+/* end of navbar section */
 
 /* building card tabs */
 .tabs .nav-link,
@@ -213,20 +213,8 @@ body {
 /* end of misc */
 
 /* map and building lists */
-.map-and-list-container {
+.map-container {
   width: 100%;
-  height: 78vh;
-}
-
-@media (max-width: 768px) {
-  .map-and-list-container {
-    height: 70vh;
-  }
-}
-
-@media (max-width: 576px) {
-  .map-and-list-container {
-    height: 65vh;
-  }
+  height: 100%;
 }
 /* end of map and building lists */

--- a/src/interfaces/IMap.ts
+++ b/src/interfaces/IMap.ts
@@ -4,4 +4,5 @@ import ISavedBuilding from "./ISavedBuilding";
 export default interface IMap {
   resultBuildingsUnsorted: Array<IBuilding>;
   savedBuildings: Array<ISavedBuilding>;
+  mapHeight: number;
 }

--- a/src/interfaces/IPage.ts
+++ b/src/interfaces/IPage.ts
@@ -1,3 +1,4 @@
 export default interface IPage {
   name: string;
+  topNavRef: React.MutableRefObject<HTMLDivElement | null>;
 }

--- a/src/map/ReactMap.tsx
+++ b/src/map/ReactMap.tsx
@@ -22,6 +22,7 @@ const center = {
 const ReactMap: React.FC<IMap> = ({
   resultBuildingsUnsorted = [],
   savedBuildings,
+  mapHeight,
 }) => {
   const [selectedBuilding, setSelectedBuilding] = useState<IBuilding | null>(
     null
@@ -53,9 +54,12 @@ const ReactMap: React.FC<IMap> = ({
     isLoaded && (
       <Container fluid>
         <Row>
-          <Col className="p-0">
+          <Col
+            className="p-0 map-and-list-container"
+            style={{ width: "100%", height: mapHeight }}
+          >
             <GoogleMap
-              mapContainerClassName="map-and-list-container"
+              mapContainerClassName="map-container"
               center={center}
               zoom={12.5}
               options={{ mapId: "c8d48b060a22a457" }}

--- a/src/pages/AllBuildings.tsx
+++ b/src/pages/AllBuildings.tsx
@@ -122,9 +122,13 @@ const AllBuildingsPage: React.FC<IPage> = ({ topNavRef }) => {
       const sideNavHeight = sideNavRef.current.offsetHeight;
       const windowHeight = window.innerHeight;
 
-      // The 5px is to eliminate the scrollbar
+      // The 10px is to eliminate the scrollbar
       const newMapHeight =
-        windowHeight - topNavHeight - searchAndFilterHeight - sideNavHeight - 5;
+        windowHeight -
+        topNavHeight -
+        searchAndFilterHeight -
+        sideNavHeight -
+        10;
       setMapHeight(newMapHeight);
     };
 

--- a/src/pages/AllBuildings.tsx
+++ b/src/pages/AllBuildings.tsx
@@ -165,7 +165,7 @@ const AllBuildingsPage: React.FC<IPage> = ({ topNavRef }) => {
         }
       }}
     >
-      <div className="pt-2" ref={searchAndFilterRef}>
+      <div className="all-buildings-page pt-2" ref={searchAndFilterRef}>
         <SearchAndFilter
           setSearchQuery={setSearchQuery}
           allNeighborhoods={allNeighborhoods}


### PR DESCRIPTION
Changes:
- Contents perfect fit to screen size
- Mobile navbar is now an offcanvas (made above calculations easier)

(Force pushed to clean up lots of commits to test on mobile)

Before
<img width="1399" alt="Screen Shot 2025-02-26 at 3 40 55 PM" src="https://github.com/user-attachments/assets/2d59296f-a213-4086-8751-84faa9d485d0" />
<img width="311" alt="Screen Shot 2025-02-26 at 3 41 21 PM" src="https://github.com/user-attachments/assets/218c542d-4258-45e7-8368-851b517d45e2" />
<img width="309" alt="Screen Shot 2025-02-26 at 9 59 54 PM" src="https://github.com/user-attachments/assets/7589f727-d94f-4f2c-966e-ba03bf6a57f7" />

After
<img width="1157" alt="Screen Shot 2025-02-26 at 3 42 06 PM" src="https://github.com/user-attachments/assets/63cf6dab-1ed6-4630-806a-d448d543cf84" />
<img width="311" alt="Screen Shot 2025-02-26 at 3 41 48 PM" src="https://github.com/user-attachments/assets/b4346a3a-b05e-403d-9209-f11d5a004c2a" />
<img width="375" alt="Screen Shot 2025-02-26 at 9 59 33 PM" src="https://github.com/user-attachments/assets/f991b998-fa5e-4300-80a7-1089d63bfee4" />
