### PR TITLE
Compare new and existing temp building data before writing to collection

### DIFF
--- a/src/utils/firestoreUtilHelpers.ts
+++ b/src/utils/firestoreUtilHelpers.ts
@@ -1,0 +1,49 @@
+import { Address, AmiData, Contact } from "../interfaces/IBuilding";
+
+export function isSameAddress(a: Address, b: Partial<Address>): boolean {
+  return (
+    a.streetNum === b.streetNum &&
+    a.street === b.street &&
+    a.city === b.city &&
+    a.state === b.state &&
+    a.zip === b.zip &&
+    a.neighborhood === b.neighborhood &&
+    a.streetAddress === b.streetAddress &&
+    a.lat === b.lat &&
+    a.lng === b.lng
+  );
+}
+
+export function isSameContact(a: Contact, b: Partial<Contact>): boolean {
+  return (
+    a.phone === b.phone &&
+    a.phone2 === b.phone2 &&
+    a.urlForBuilding === b.urlForBuilding
+  );
+}
+
+export function isSameAmiData(a: AmiData, b: AmiData): boolean {
+  const aKeys = Object.keys(a) as (keyof AmiData)[];
+  const bKeys = Object.keys(b) as (keyof AmiData)[];
+
+  if (aKeys.length !== bKeys.length) return false;
+
+  for (const key of aKeys) {
+    const aValues = a[key];
+    const bValues = b[key];
+
+    if (!bValues || aValues.length !== bValues.length) {
+      return false;
+    }
+
+    // Compare sorted arrays to ensure order doesn't matter
+    const sortedA = [...aValues].sort();
+    const sortedB = [...bValues].sort();
+
+    for (let i = 0; i < sortedA.length; i++) {
+      if (sortedA[i] !== sortedB[i]) return false;
+    }
+  }
+
+  return true;
+}

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -151,6 +151,7 @@ async function setTempBuilding(
   }
 
   try {
+    // Temp building uses same ID as associated listing.
     const tempBuildingDocRef = listingID
       ? doc(db, "temp_buildings", listingID)
       : doc(collection(db, "temp_buildings"));

--- a/src/utils/firestoreUtils.ts
+++ b/src/utils/firestoreUtils.ts
@@ -18,6 +18,11 @@ import {
   ProgramKeyEnum,
 } from "../types/enumTypes";
 import { getMaxExpiryDate } from "./generalUtils";
+import {
+  isSameAddress,
+  isSameContact,
+  isSameAmiData,
+} from "./firestoreUtilHelpers";
 
 import IListing, { AvailDataArray } from "../interfaces/IListing";
 import {
@@ -104,17 +109,48 @@ async function setTempBuilding(
     amiData,
   } = selectedBuilding;
 
+  const finalBuildingName = otherBuildingName
+    ? otherBuildingName
+    : buildingName;
+  const finalBuildingID = buildingID || randomTempBuildingID;
+
   const tempBuilding: ITempBuilding = {
-    buildingName: otherBuildingName ? otherBuildingName : buildingName,
-    buildingID: buildingID || randomTempBuildingID,
+    buildingName: finalBuildingName,
+    buildingID: finalBuildingID,
     address: address,
     contact: contact,
     amiData: amiData,
     listingID: listingID,
   };
 
+  // Temp building uses same ID as associated listing.
+  // Check if the building already exists in buildings collection and is the same
+  if (buildingID) {
+    try {
+      const existingDocRef = doc(db, "buildings_3", buildingID);
+      const existingDocSnap = await getDoc(existingDocRef);
+
+      if (existingDocSnap.exists()) {
+        const existingData = existingDocSnap.data();
+
+        const isSame =
+          existingData.buildingName === finalBuildingName &&
+          isSameAddress(existingData.address, address) &&
+          isSameContact(existingData.contact, contact) &&
+          isSameAmiData(existingData.amiData, amiData);
+
+        if (isSame) {
+          // Skip writing to temp_buildings
+          return;
+        }
+      }
+    } catch (error) {
+      console.error("Error checking existing building:", error);
+      // Continue to temp building write in case of read error
+    }
+  }
+
   try {
-    // Temp building uses same ID as associated listing.
     const tempBuildingDocRef = listingID
       ? doc(db, "temp_buildings", listingID)
       : doc(collection(db, "temp_buildings"));


### PR DESCRIPTION
Quick fix for all buildings saving to temp - should only save if there's an update in building data.
Deep checks building data.