### PR TITLE
Building sort and optional url label updates

### DIFF
--- a/src/components/AvailUnitsTable.tsx
+++ b/src/components/AvailUnitsTable.tsx
@@ -135,7 +135,7 @@ const EditListingForm: React.FC<EditListingFormProps> = ({
                     <th key={key} style={{ minWidth: colWidths.links }}>
                       {label}
                       <div>
-                        <Form.Text>Optional</Form.Text>
+                        <Form.Text>Optional URL</Form.Text>
                       </div>
                     </th>
                   ))}

--- a/src/components/EditListingForm.tsx
+++ b/src/components/EditListingForm.tsx
@@ -347,15 +347,17 @@ const EditListingForm: React.FC<EditListingFormProps> = ({
                 <option value="">Select</option>
                 <option value="Not Listed">Not Listed</option>
                 <Dropdown.Divider />
-                {allBuildings.map((building) => (
-                  <option
-                    key={building.buildingID}
-                    value={building.buildingName}
-                    data-buildingid={building.buildingID}
-                  >
-                    {building.buildingName}
-                  </option>
-                ))}
+                {allBuildings
+                  .sort((a, b) => a.buildingName.localeCompare(b.buildingName))
+                  .map((building) => (
+                    <option
+                      key={building.buildingID}
+                      value={building.buildingName}
+                      data-buildingid={building.buildingID}
+                    >
+                      {building.buildingName}
+                    </option>
+                  ))}
               </Form.Select>
             </Col>
           </Row>

--- a/src/hooks/useAllBuildings.ts
+++ b/src/hooks/useAllBuildings.ts
@@ -46,17 +46,24 @@ export const useAllBuildings = (): [IBuilding[], boolean] => {
         }
         buildings.push(building);
       });
-      // Most recently updated listing is first
-      const sortedBuildings = buildings.sort(
-        (buildingA: IBuilding, buildingB: IBuilding) => {
-          const dateUpdatedA =
-            buildingA.listing?.dateUpdated?.toMillis?.() || 0;
-          const dateUpdatedB =
-            buildingB.listing?.dateUpdated?.toMillis?.() || 0;
+      // Most recently updated listing, with availability, is first
+      const sortedBuildings = buildings.sort((a: IBuilding, b: IBuilding) => {
+        const aNoneAvailable = a.listing?.noneAvailable ?? false;
+        const bNoneAvailable = b.listing?.noneAvailable ?? false;
 
-          return dateUpdatedB - dateUpdatedA;
-        }
-      );
+        // If both are marked noneAvailable, don't change their order
+        if (aNoneAvailable && bNoneAvailable) return 0;
+
+        // If only one is noneAvailable, keep its position (don't swap)
+        if (aNoneAvailable) return 1; // move a down
+        if (bNoneAvailable) return -1; // move b down
+
+        // Otherwise, sort by dateUpdated (most recent first)
+        const aUpdated = a.listing?.dateUpdated?.toMillis?.() || 0;
+        const bUpdated = b.listing?.dateUpdated?.toMillis?.() || 0;
+
+        return bUpdated - aUpdated;
+      });
 
       setAllBuildings(sortedBuildings);
       setIsLoadingAllBuildings(false);

--- a/src/types/enumTypes.ts
+++ b/src/types/enumTypes.ts
@@ -68,11 +68,11 @@ export enum OptionalUrlsKeyEnum {
 }
 
 export enum OptionalUrlsLabelEnum {
-  listingPageUrl = "Listing Page URL",
-  walkTourUrl = "Walk Tour URL",
-  floorPlanUrl = "Floor Plan URL",
-  otherUrl1 = "Other URL 1",
-  otherUrl2 = "Other URL 2",
+  listingPageUrl = "Listing Page",
+  walkTourUrl = "Walk Tour",
+  floorPlanUrl = "Floor Plan",
+  otherUrl1 = "Additional Link",
+  otherUrl2 = "Additional Link 2",
 }
 
 export enum TableParentEnum {


### PR DESCRIPTION
Before:
<img width="1420" alt="Screen Shot 2025-04-16 at 3 05 50 PM" src="https://github.com/user-attachments/assets/97aef19d-b25a-4d23-be93-57c0189c685e" />
<img width="697" alt="Screen Shot 2025-04-16 at 3 06 08 PM" src="https://github.com/user-attachments/assets/b9f85acb-f72a-411a-9963-0c5d5a6dab9e" />
<img width="744" alt="Screen Shot 2025-04-16 at 3 06 20 PM" src="https://github.com/user-attachments/assets/5b5ab53d-3786-4225-9ce5-3a4d23be4ae8" />
<img width="770" alt="Screen Shot 2025-04-16 at 3 06 29 PM" src="https://github.com/user-attachments/assets/4a7183ca-3c7b-4e61-a292-f9e51093f14d" />

After:
<img width="1428" alt="Screen Shot 2025-04-16 at 3 08 05 PM" src="https://github.com/user-attachments/assets/a87ad241-518d-4088-abcd-e2972f8e5a8c" />
<img width="450" alt="Screen Shot 2025-04-16 at 3 08 21 PM" src="https://github.com/user-attachments/assets/37af6ae4-85ad-4925-8672-859f3aa32468" />
<img width="713" alt="Screen Shot 2025-04-16 at 3 08 38 PM" src="https://github.com/user-attachments/assets/117ff400-9e9e-4313-aea1-304a777f76be" />
<img width="800" alt="Screen Shot 2025-04-16 at 3 08 52 PM" src="https://github.com/user-attachments/assets/7b718e9f-569d-46a6-9968-4fc6fb6327c7" />
