### PR TITLE
tiny: PWA title update

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       },
       manifest: {
         short_name: "MFTE Seattle",
-        name: "MFTE Seattle - Find Rent-Reduced Apartments",
+        name: "Find Rent-Reduced Apartments",
         start_url: "/",
         display: "standalone",
         background_color: "#e2fbfd",


### PR DESCRIPTION
The header of the PWA was repetitive "MFTE Seattle - Find Rent-Reduced Apartments - MFTE Seattle"
because it is a combination of `index.html` <title> and vite manifest title