### PR TITLE
Improved app performance - moved context providers down tree, small UI change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,26 @@
 import { useRef, useState } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import PrivateRoute from "./components/auth/PrivateRoute";
 import config from "./config/config";
 import privateRoutes from "./config/privateRoutes";
 import publicRoutes from "./config/publicRoutes";
-
-import RenderProfiler from "./components/utility/RenderProfiler";
+import PrivateRoute from "./components/auth/PrivateRoute";
 import { TopNav } from "./components/navbars/TopNav";
 import { Footer } from "./components/navbars/Footer";
-
+import RenderProfiler from "./components/utility/RenderProfiler";
 import AuthProvider from "./contexts/AuthContext";
-import { AllBuildingsProvider } from "./contexts/AllBuildingsContext";
-import { HouseholdProvider } from "./contexts/HouseholdContext";
 import { ModalContext, ModalState } from "./contexts/ModalContext";
-import { TempBuildingsProvider } from "./contexts/TempBuildingsContext";
-import { UnitAvailDataProvider } from "./contexts/UnitAvailDataContext";
 
 const Application: React.FC = () => {
   const modalStateHook = useState(ModalState.HIDDEN);
   const topNavRef = useRef<HTMLDivElement | null>(null);
+
+  const composeProviders =
+    (providers: React.ComponentType<{ children: React.ReactNode }>[]) =>
+    (children: React.ReactNode) =>
+      providers.reduceRight(
+        (acc, Provider) => <Provider>{acc}</Provider>,
+        children
+      );
 
   return (
     <RenderProfiler id="Application" isProfilerOn={config.debug.isProfilerOn}>
@@ -29,38 +31,43 @@ const Application: React.FC = () => {
               <div ref={topNavRef}>
                 <TopNav />
               </div>
-              <AllBuildingsProvider>
-                <TempBuildingsProvider>
-                  <HouseholdProvider>
-                    <UnitAvailDataProvider>
-                      <Routes>
-                        {privateRoutes.map((route) => (
-                          <Route
-                            key={route.name}
-                            path={route.path}
-                            element={
-                              <PrivateRoute name={route.name}>
-                                <route.component />
-                              </PrivateRoute>
-                            }
-                          />
-                        ))}
+              <Routes>
+                {privateRoutes.map(({ name, path, component: Component }) => (
+                  <Route
+                    key={name}
+                    path={path}
+                    element={
+                      <PrivateRoute name={name}>
+                        <Component />
+                      </PrivateRoute>
+                    }
+                  />
+                ))}
 
-                        {publicRoutes.map((route) => (
-                          <Route
-                            key={route.name}
-                            path={route.path}
-                            element={<route.component topNavRef={topNavRef} />}
-                          />
-                        ))}
-                      </Routes>
-                    </UnitAvailDataProvider>
-                  </HouseholdProvider>
-                </TempBuildingsProvider>
-              </AllBuildingsProvider>
+                {publicRoutes.map(
+                  ({
+                    name,
+                    path,
+                    component: Component,
+                    wrapWith = [],
+                    props,
+                  }) => {
+                    const element = (
+                      <Component {...(props || {})} topNavRef={topNavRef} />
+                    );
+
+                    const wrappedElement = wrapWith.length
+                      ? composeProviders(wrapWith)(element)
+                      : element;
+
+                    return (
+                      <Route key={name} path={path} element={wrappedElement} />
+                    );
+                  }
+                )}
+              </Routes>
             </ModalContext.Provider>
           </AuthProvider>
-
           <Footer />
         </BrowserRouter>
       </div>

--- a/src/components/all-buildings/BuildingsList.tsx
+++ b/src/components/all-buildings/BuildingsList.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useRef } from "react";
+import { MutableRefObject, useRef } from "react";
 import BuildingCard from "./BuildingCard";
 import { willShowAvailTable } from "../../utils/generalUtils";
 import IBuilding from "../../interfaces/IBuilding";
@@ -37,19 +37,6 @@ const AllBuildingsList: React.FC<AllBuildingsListProps> = ({
   selectedBuildingId,
 }) => {
   const buildingRefs = useRef<Record<string, HTMLDivElement | null>>({});
-
-  useEffect(() => {
-    if (selectedBuildingId && buildingRefs.current[selectedBuildingId]) {
-      buildingRefs.current[selectedBuildingId]?.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
-    }
-  }, [selectedBuildingId]);
-
-  if (!resultBuildingsUnsorted) {
-    return null;
-  }
 
   return (
     <Container fluid>

--- a/src/components/map/ReactMap.tsx
+++ b/src/components/map/ReactMap.tsx
@@ -10,24 +10,7 @@ import IMap from "../../interfaces/IMap";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
-
-const seattle = {
-  lat: 47.62,
-  lng: -122.315,
-};
-
-const mapTypeControlOptions = window.google
-  ? {
-      style: window.google.maps.MapTypeControlStyle.DROPDOWN_MENU,
-      position: window.google.maps.ControlPosition.TOP_LEFT,
-      mapTypeIds: [
-        window.google.maps.MapTypeId.ROADMAP,
-        window.google.maps.MapTypeId.SATELLITE,
-        window.google.maps.MapTypeId.TERRAIN,
-        window.google.maps.MapTypeId.HYBRID,
-      ],
-    }
-  : undefined;
+import { useState } from "react";
 
 const ReactMap: React.FC<IMap> = ({
   resultBuildingsUnsorted = [],
@@ -37,44 +20,67 @@ const ReactMap: React.FC<IMap> = ({
   setSelectedBuildingId,
   selectedBuildingId,
 }) => {
+  const [isMapLoaded, setIsMapLoaded] = useState(false);
+
+  const seattleCoordinates = {
+    lat: 47.62,
+    lng: -122.315,
+  };
+
+  const mapTypeControlOptions = {
+    style: window.google.maps.MapTypeControlStyle.DROPDOWN_MENU,
+    position: window.google.maps.ControlPosition.TOP_LEFT,
+    mapTypeIds: [
+      window.google.maps.MapTypeId.ROADMAP,
+      window.google.maps.MapTypeId.SATELLITE,
+      window.google.maps.MapTypeId.TERRAIN,
+      window.google.maps.MapTypeId.HYBRID,
+    ],
+  };
+
   return (
     <APIProvider
       apiKey={firebaseConfig.apiKey}
-      onLoad={() => console.log("Maps API has loaded.")}
+      onLoad={() => {
+        console.log("Maps API has loaded.");
+        setIsMapLoaded(true);
+      }}
     >
-      <Container fluid>
-        <Row>
-          <Col
-            className="p-0 map-and-list-container"
-            style={{ width: "100%", height: mapHeight }}
-          >
-            <Map
-              className="map-container"
-              defaultZoom={10.9}
-              defaultCenter={seattle}
-              mapId={"c8d48b060a22a457"}
-              onCameraChanged={(ev: MapCameraChangedEvent) =>
-                console.log(
-                  "camera changed:",
-                  ev.detail.center,
-                  "zoom:",
-                  ev.detail.zoom
-                )
-              }
-              mapTypeControl={true}
-              mapTypeControlOptions={mapTypeControlOptions}
+      {isMapLoaded && (
+        <Container fluid>
+          <Row>
+            <Col
+              className="p-0 map-and-list-container"
+              style={{ width: "100%", height: mapHeight }}
             >
-              <AllMarkers
-                buildingsToMap={resultBuildingsUnsorted}
-                shouldScroll={shouldScroll}
-                savedBuildings={savedBuildings}
-                setSelectedBuildingId={setSelectedBuildingId}
-                selectedBuildingId={selectedBuildingId}
-              />
-            </Map>
-          </Col>
-        </Row>
-      </Container>
+              <Map
+                className="map-container"
+                defaultZoom={10.9}
+                defaultCenter={seattleCoordinates}
+                mapId={"c8d48b060a22a457"}
+                onCameraChanged={(ev: MapCameraChangedEvent) =>
+                  console.log(
+                    "camera changed:",
+                    ev.detail.center,
+                    "zoom:",
+                    ev.detail.zoom
+                  )
+                }
+                mapTypeControl={true}
+                mapTypeControlOptions={mapTypeControlOptions}
+              >
+                <AllMarkers
+                  buildingsToMap={resultBuildingsUnsorted}
+                  shouldScroll={shouldScroll}
+                  savedBuildings={savedBuildings}
+                  setSelectedBuildingId={setSelectedBuildingId}
+                  selectedBuildingId={selectedBuildingId}
+                />
+              </Map>
+            </Col>
+          </Row>
+        </Container>
+      )}
     </APIProvider>
   );
 };

--- a/src/components/map/ReactMap.tsx
+++ b/src/components/map/ReactMap.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   APIProvider,
   Map,
@@ -17,6 +16,19 @@ const seattle = {
   lng: -122.315,
 };
 
+const mapTypeControlOptions = window.google
+  ? {
+      style: window.google.maps.MapTypeControlStyle.DROPDOWN_MENU,
+      position: window.google.maps.ControlPosition.TOP_LEFT,
+      mapTypeIds: [
+        window.google.maps.MapTypeId.ROADMAP,
+        window.google.maps.MapTypeId.SATELLITE,
+        window.google.maps.MapTypeId.TERRAIN,
+        window.google.maps.MapTypeId.HYBRID,
+      ],
+    }
+  : undefined;
+
 const ReactMap: React.FC<IMap> = ({
   resultBuildingsUnsorted = [],
   savedBuildings,
@@ -25,57 +37,44 @@ const ReactMap: React.FC<IMap> = ({
   setSelectedBuildingId,
   selectedBuildingId,
 }) => {
-  const [isMapLoaded, setIsMapLoaded] = useState(false);
-
   return (
     <APIProvider
       apiKey={firebaseConfig.apiKey}
-      onLoad={() => setIsMapLoaded(true)}
+      onLoad={() => console.log("Maps API has loaded.")}
     >
-      {isMapLoaded && (
-        <Container fluid>
-          <Row>
-            <Col
-              className="p-0 map-and-list-container"
-              style={{ width: "100%", height: mapHeight }}
+      <Container fluid>
+        <Row>
+          <Col
+            className="p-0 map-and-list-container"
+            style={{ width: "100%", height: mapHeight }}
+          >
+            <Map
+              className="map-container"
+              defaultZoom={10.9}
+              defaultCenter={seattle}
+              mapId={"c8d48b060a22a457"}
+              onCameraChanged={(ev: MapCameraChangedEvent) =>
+                console.log(
+                  "camera changed:",
+                  ev.detail.center,
+                  "zoom:",
+                  ev.detail.zoom
+                )
+              }
+              mapTypeControl={true}
+              mapTypeControlOptions={mapTypeControlOptions}
             >
-              <Map
-                className="map-container"
-                defaultZoom={10.9}
-                defaultCenter={seattle}
-                mapId={"c8d48b060a22a457"}
-                onCameraChanged={(ev: MapCameraChangedEvent) =>
-                  console.log(
-                    "camera changed:",
-                    ev.detail.center,
-                    "zoom:",
-                    ev.detail.zoom
-                  )
-                }
-                mapTypeControl={true}
-                mapTypeControlOptions={{
-                  style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
-                  position: google.maps.ControlPosition.TOP_LEFT,
-                  mapTypeIds: [
-                    google.maps.MapTypeId.ROADMAP,
-                    google.maps.MapTypeId.SATELLITE,
-                    google.maps.MapTypeId.TERRAIN,
-                    google.maps.MapTypeId.HYBRID,
-                  ],
-                }}
-              >
-                <AllMarkers
-                  buildingsToMap={resultBuildingsUnsorted}
-                  shouldScroll={shouldScroll}
-                  savedBuildings={savedBuildings}
-                  setSelectedBuildingId={setSelectedBuildingId}
-                  selectedBuildingId={selectedBuildingId}
-                />
-              </Map>
-            </Col>
-          </Row>
-        </Container>
-      )}
+              <AllMarkers
+                buildingsToMap={resultBuildingsUnsorted}
+                shouldScroll={shouldScroll}
+                savedBuildings={savedBuildings}
+                setSelectedBuildingId={setSelectedBuildingId}
+                selectedBuildingId={selectedBuildingId}
+              />
+            </Map>
+          </Col>
+        </Row>
+      </Container>
     </APIProvider>
   );
 };

--- a/src/config/publicRoutes.ts
+++ b/src/config/publicRoutes.ts
@@ -1,5 +1,6 @@
 import IRoute from "../interfaces/IRoute";
-
+import { AllBuildingsProvider } from "../contexts/AllBuildingsContext";
+import { HouseholdProvider } from "../contexts/HouseholdContext";
 import AboutPage from "../pages/public-pages/About";
 import AllBuildingsPage from "../pages/public-pages/AllBuildings";
 import ContactPage from "../pages/public-pages/Contact";
@@ -21,6 +22,7 @@ const publicRoutes: IRoute[] = [
     name: "All Buildings Page",
     component: AllBuildingsPage,
     exact: true,
+    wrapWith: [AllBuildingsProvider, HouseholdProvider],
   },
   {
     path: "/about",

--- a/src/config/publicRoutes.ts
+++ b/src/config/publicRoutes.ts
@@ -16,6 +16,7 @@ const publicRoutes: IRoute[] = [
     name: "All Buildings Page",
     component: AllBuildingsPage,
     exact: true,
+    wrapWith: [AllBuildingsProvider, HouseholdProvider],
   },
   {
     path: "/all-buildings",

--- a/src/interfaces/IRoute.ts
+++ b/src/interfaces/IRoute.ts
@@ -1,7 +1,10 @@
+import { ComponentType, ReactNode } from "react";
+
 export default interface IRoute {
   path: string;
   name: string;
   exact: boolean;
-  component: any;
-  props?: any;
+  component: ComponentType<any>;
+  wrapWith?: ComponentType<{ children: ReactNode }>[];
+  props?: Record<string, unknown>;
 }

--- a/src/pages/public-pages/AllBuildings.tsx
+++ b/src/pages/public-pages/AllBuildings.tsx
@@ -43,6 +43,7 @@ export type HandleCheckboxChange = (
 const AllBuildingsPage: React.FC<IPage> = ({ topNavRef }) => {
   const [allBuildings, isLoadingAllBuildings] = useAllBuildingsContext();
   const [savedBuildings] = useSavedBuildings();
+
   const [selectedBuildingId, setSelectedBuildingId] = useState<string | null>(
     null
   );

--- a/src/pages/public-pages/AllBuildings.tsx
+++ b/src/pages/public-pages/AllBuildings.tsx
@@ -7,8 +7,13 @@ import {
   useLayoutEffect,
 } from "react";
 import config from "../../config/config";
-
-import { useAllBuildingsContext } from "../../contexts/AllBuildingsContext";
+import {
+  AllBuildingsProvider,
+  useAllBuildingsContext,
+} from "../../contexts/AllBuildingsContext";
+import { HouseholdProvider } from "../../contexts/HouseholdContext";
+import { TempBuildingsProvider } from "../../contexts/TempBuildingsContext";
+import { UnitAvailDataProvider } from "../../contexts/UnitAvailDataContext";
 import { useSavedBuildings } from "../../hooks/useSavedBuildings";
 
 import AllBuildingsList from "../../components/all-buildings/BuildingsList";
@@ -145,104 +150,115 @@ const AllBuildingsPage: React.FC<IPage> = ({ topNavRef }) => {
 
   return (
     <RenderProfiler id="AllBuildings" isProfilerOn={config.debug.isProfilerOn}>
-      <div className="all-buildings-page pt-2" ref={searchAndFilterRef}>
-        <SearchAndFilter
-          setSearchQuery={setSearchQuery}
-          allNeighborhoods={allNeighborhoods}
-          allAmi={allAmi}
-          activeFilters={activeFilters}
-          dispatch={dispatch}
-        />
-      </div>
+      <AllBuildingsProvider>
+        <TempBuildingsProvider>
+          <HouseholdProvider>
+            <UnitAvailDataProvider>
+              <div className="all-buildings-page pt-2" ref={searchAndFilterRef}>
+                <SearchAndFilter
+                  setSearchQuery={setSearchQuery}
+                  allNeighborhoods={allNeighborhoods}
+                  allAmi={allAmi}
+                  activeFilters={activeFilters}
+                  dispatch={dispatch}
+                />
+              </div>
 
-      {/* Only visible on large screens */}
-      <Container fluid className="d-none d-md-block map-and-list-container">
-        <Row>
-          <Col className="px-1" ref={mapContainerRef}>
-            <ReactMap
-              mapHeight={mapHeight}
-              resultBuildingsUnsorted={resultBuildingsUnsorted}
-              savedBuildings={savedBuildings}
-              shouldScroll={shouldScroll}
-              setSelectedBuildingId={setSelectedBuildingId}
-              selectedBuildingId={selectedBuildingId}
-            />
-          </Col>
-          <Col
-            className="px-0"
-            style={{
-              height: `${mapHeight}px`,
-              overflowY: "auto",
-            }}
-            // Ref to scroll to the top of the list on search input
-            ref={buildingsListRef}
-          >
-            <AllBuildingsList
-              isLoading={isLoadingAllBuildings}
-              resultBuildingsUnsorted={resultBuildingsUnsorted}
-              savedBuildings={savedBuildings}
-              shouldScroll={shouldScroll}
-              setSelectedBuildingId={setSelectedBuildingId}
-              selectedBuildingId={selectedBuildingId}
-            />
-          </Col>
-        </Row>
-      </Container>
+              {/* Only visible on large screens */}
+              <Container
+                fluid
+                className="d-none d-md-block map-and-list-container"
+              >
+                <Row>
+                  <Col className="px-1" ref={mapContainerRef}>
+                    <ReactMap
+                      mapHeight={mapHeight}
+                      resultBuildingsUnsorted={resultBuildingsUnsorted}
+                      savedBuildings={savedBuildings}
+                      shouldScroll={shouldScroll}
+                      setSelectedBuildingId={setSelectedBuildingId}
+                      selectedBuildingId={selectedBuildingId}
+                    />
+                  </Col>
+                  <Col
+                    className="px-0"
+                    style={{
+                      height: `${mapHeight}px`,
+                      overflowY: "auto",
+                    }}
+                    // Ref to scroll to the top of the list on search input
+                    ref={buildingsListRef}
+                  >
+                    <AllBuildingsList
+                      isLoading={isLoadingAllBuildings}
+                      resultBuildingsUnsorted={resultBuildingsUnsorted}
+                      savedBuildings={savedBuildings}
+                      shouldScroll={shouldScroll}
+                      setSelectedBuildingId={setSelectedBuildingId}
+                      selectedBuildingId={selectedBuildingId}
+                    />
+                  </Col>
+                </Row>
+              </Container>
 
-      {/* Only visible on small screens */}
-      <Container
-        fluid
-        className="d-block d-md-none mt-1 map-and-list-container"
-      >
-        <Tab.Container id="sidebar" defaultActiveKey="map">
-          <div ref={sideNavRef}>
-            <Nav
-              variant="pills"
-              className="mb-1 small d-flex justify-content-end"
-            >
-              <Nav.Item>
-                <Nav.Link
-                  eventKey="map"
-                  className="tab small py-1 px-2 text-size-override"
-                >
-                  Map View
-                </Nav.Link>
-              </Nav.Item>
-              <Nav.Item>
-                <Nav.Link
-                  eventKey="list"
-                  className="tab small py-1 px-2 text-size-override"
-                >
-                  List View
-                </Nav.Link>
-              </Nav.Item>
-            </Nav>
-          </div>
+              {/* Only visible on small screens */}
+              <Container
+                fluid
+                className="d-block d-md-none mt-1 map-and-list-container"
+              >
+                <Tab.Container id="sidebar" defaultActiveKey="map">
+                  <div ref={sideNavRef}>
+                    <Nav
+                      variant="pills"
+                      className="mb-1 small d-flex justify-content-end"
+                    >
+                      <Nav.Item>
+                        <Nav.Link
+                          eventKey="map"
+                          className="tab small py-1 px-2 text-size-override"
+                        >
+                          Map View
+                        </Nav.Link>
+                      </Nav.Item>
+                      <Nav.Item>
+                        <Nav.Link
+                          eventKey="list"
+                          className="tab small py-1 px-2 text-size-override"
+                        >
+                          List View
+                        </Nav.Link>
+                      </Nav.Item>
+                    </Nav>
+                  </div>
 
-          <Tab.Content ref={mapContainerRef}>
-            <Tab.Pane eventKey="map">
-              <ReactMap
-                resultBuildingsUnsorted={resultBuildingsUnsorted}
-                savedBuildings={savedBuildings}
-                mapHeight={mapHeight}
-                shouldScroll={shouldScroll}
-                setSelectedBuildingId={setSelectedBuildingId}
-                selectedBuildingId={selectedBuildingId}
-              />
-            </Tab.Pane>
-            <Tab.Pane eventKey="list">
-              <AllBuildingsList
-                isLoading={isLoadingAllBuildings}
-                resultBuildingsUnsorted={resultBuildingsUnsorted}
-                savedBuildings={savedBuildings}
-                shouldScroll={shouldScroll}
-                setSelectedBuildingId={setSelectedBuildingId}
-                selectedBuildingId={selectedBuildingId}
-              />
-            </Tab.Pane>
-          </Tab.Content>
-        </Tab.Container>
-      </Container>
+                  <Tab.Content ref={mapContainerRef}>
+                    <Tab.Pane eventKey="map">
+                      <ReactMap
+                        resultBuildingsUnsorted={resultBuildingsUnsorted}
+                        savedBuildings={savedBuildings}
+                        mapHeight={mapHeight}
+                        shouldScroll={shouldScroll}
+                        setSelectedBuildingId={setSelectedBuildingId}
+                        selectedBuildingId={selectedBuildingId}
+                      />
+                    </Tab.Pane>
+                    <Tab.Pane eventKey="list">
+                      <AllBuildingsList
+                        isLoading={isLoadingAllBuildings}
+                        resultBuildingsUnsorted={resultBuildingsUnsorted}
+                        savedBuildings={savedBuildings}
+                        shouldScroll={shouldScroll}
+                        setSelectedBuildingId={setSelectedBuildingId}
+                        selectedBuildingId={selectedBuildingId}
+                      />
+                    </Tab.Pane>
+                  </Tab.Content>
+                </Tab.Container>
+              </Container>
+            </UnitAvailDataProvider>
+          </HouseholdProvider>
+        </TempBuildingsProvider>
+      </AllBuildingsProvider>
     </RenderProfiler>
   );
 };


### PR DESCRIPTION
**Changes summary**
- moved some providers down the component tree to improve app performance.
- removed scroll on building card click. It just wasn't a pleasant UI.

Explored moving `isBuildingSelected` state - or using refs instead to prevent all markers from reloading on click, however, given that clustering needs to recalculate on map move, and map moves on click, this does not seem straightforward to do, so leaving as is.